### PR TITLE
Fix await coroutine for numbers and selects

### DIFF
--- a/custom_components/stiebel_eltron_isg/number.py
+++ b/custom_components/stiebel_eltron_isg/number.py
@@ -247,7 +247,7 @@ class StiebelEltronISGNumberEntity(StiebelEltronISGEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
-        self.coordinator.set_data(self.entity_description.key, value)
+        await self.coordinator.set_data(self.entity_description.key, value)
 
     @property
     def native_value(self):

--- a/custom_components/stiebel_eltron_isg/select.py
+++ b/custom_components/stiebel_eltron_isg/select.py
@@ -106,7 +106,7 @@ class StiebelEltronISGSelectEntity(StiebelEltronISGEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Update the current selected option."""
         key = get_key_from_value(self._options, option)
-        self.coordinator.set_data(self.entity_description.key, key)
+        await self.coordinator.set_data(self.entity_description.key, key)
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
During the development on #268 I ran into these errors:
```
2024-06-28 18:03:25.333 WARNING (MainThread) [py.warnings] /workspaces/stiebel_eltron_isg_component/custom_components/stiebel_eltron_isg/select.py:109: RuntimeWarning: coroutine 'StiebelEltronModbusLWZDataCoordinator.set_data' was never awaited
Coroutine created at (most recent call last)
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/components/websocket_api/commands.py", line 241, in handle_call_service
    response = await hass.services.async_call(
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/core.py", line 2741, in async_call
    response_data = await coro
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/core.py", line 2784, in _execute_service
    return await target(service_call)
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/helpers/service.py", line 977, in entity_service_call
    single_response = await _handle_entity_call(
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/helpers/service.py", line 1041, in _handle_entity_call
    task = hass.async_run_hass_job(job)
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/core.py", line 939, in async_run_hass_job
    return self._async_add_hass_job(hassjob, *args, background=background)
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/core.py", line 748, in _async_add_hass_job
    task = create_eager_task(
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/util/async_.py", line 37, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/components/select/__init__.py", line 191, in async_handle_select_option
    await self.async_select_option(option)
  File "/workspaces/stiebel_eltron_isg_component/custom_components/stiebel_eltron_isg/select.py", line 109, in async_select_option
    self.coordinator.set_data(self.entity_description.key, key)
  self.coordinator.set_data(self.entity_description.key, key)
  
  
2024-06-28 18:02:34.609 WARNING (MainThread) [py.warnings] /workspaces/stiebel_eltron_isg_component/custom_components/stiebel_eltron_isg/number.py:250: RuntimeWarning: coroutine 'StiebelEltronModbusLWZDataCoordinator.set_data' was never awaited
Coroutine created at (most recent call last)
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/components/websocket_api/commands.py", line 241, in handle_call_service
    response = await hass.services.async_call(
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/core.py", line 2741, in async_call
    response_data = await coro
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/core.py", line 2784, in _execute_service
    return await target(service_call)
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/helpers/service.py", line 977, in entity_service_call
    single_response = await _handle_entity_call(
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/helpers/service.py", line 1043, in _handle_entity_call
    task = hass.async_run_hass_job(func, entity, data)
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/core.py", line 939, in async_run_hass_job
    return self._async_add_hass_job(hassjob, *args, background=background)
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/core.py", line 748, in _async_add_hass_job
    task = create_eager_task(
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/util/async_.py", line 37, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/home/vscode/.local/lib/python3.12/site-packages/homeassistant/components/number/__init__.py", line 121, in async_set_value
    await entity.async_set_native_value(native_value)
  File "/workspaces/stiebel_eltron_isg_component/custom_components/stiebel_eltron_isg/number.py", line 250, in async_set_native_value
    self.coordinator.set_data(self.entity_description.key, value)
  self.coordinator.set_data(self.entity_description.key, value)
```

I have no idea why this is working in my production enviornment. But it throws errors in devcontainer and even when I change the component with the changes of #268 in my production env. This PR fixes these errors.