### PR TITLE
Fix scaling factor for heating_curve_low_end

### DIFF
--- a/custom_components/stiebel_eltron_isg/lwz_coordinator.py
+++ b/custom_components/stiebel_eltron_isg/lwz_coordinator.py
@@ -308,7 +308,6 @@ class StiebelEltronModbusLWZDataCoordinator(StiebelEltronModbusDataCoordinator):
             )
             result[HEATING_CURVE_LOW_END_HK1] = get_isg_scaled_value(
                 decoder.decode_16bit_int(),
-                100,
             )
             result[HEATING_CURVE_RISE_HK2] = get_isg_scaled_value(
                 decoder.decode_16bit_int(),
@@ -316,7 +315,6 @@ class StiebelEltronModbusLWZDataCoordinator(StiebelEltronModbusDataCoordinator):
             )
             result[HEATING_CURVE_LOW_END_HK2] = get_isg_scaled_value(
                 decoder.decode_16bit_int(),
-                100,
             )
             result[COMFORT_WATER_TEMPERATURE_TARGET] = get_isg_scaled_value(
                 decoder.decode_16bit_int(),
@@ -516,7 +514,7 @@ class StiebelEltronModbusLWZDataCoordinator(StiebelEltronModbusDataCoordinator):
         elif key == HEATING_CURVE_RISE_HK1:
             await self.write_register(address=1007, value=int(value * 100), slave=1)
         elif key == HEATING_CURVE_LOW_END_HK1:
-            await self.write_register(address=1008, value=int(value * 100), slave=1)
+            await self.write_register(address=1008, value=int(value * 10), slave=1)
         elif key == COMFORT_TEMPERATURE_TARGET_HK2:
             await self.write_register(address=1004, value=int(value * 10), slave=1)
         elif key == ECO_TEMPERATURE_TARGET_HK2:
@@ -524,7 +522,7 @@ class StiebelEltronModbusLWZDataCoordinator(StiebelEltronModbusDataCoordinator):
         elif key == HEATING_CURVE_RISE_HK2:
             await self.write_register(address=1009, value=int(value * 100), slave=1)
         elif key == HEATING_CURVE_LOW_END_HK2:
-            await self.write_register(address=1010, value=int(value * 100), slave=1)
+            await self.write_register(address=1010, value=int(value * 10), slave=1)
         elif key == COMFORT_WATER_TEMPERATURE_TARGET:
             await self.write_register(address=1011, value=int(value * 10), slave=1)
         elif key == ECO_WATER_TEMPERATURE_TARGET:


### PR DESCRIPTION
According to the documentation, the low end has data type 2 (multiplier for reading: 0.1, multiplier for writing: 10). This is tested on the real device.