### PR TITLE
Add compressor frequency sensor for LWZ devices

### DIFF
--- a/custom_components/stiebel_eltron_isg/const.py
+++ b/custom_components/stiebel_eltron_isg/const.py
@@ -137,6 +137,7 @@ CURRENT_POWER_CONSUMPTION = "current_power_consumption"
 COMPRESSOR_STARTS = "compressor_starts"
 COMPRESSOR_HEATING = "compressor_heating"
 COMPRESSOR_HEATING_WATER = "compressor_heating_water"
+COMPRESSOR_SPEED = "compressor_speed"
 ELECTRICAL_BOOSTER_HEATING = "electrical_booster_heating"
 ELECTRICAL_BOOSTER_HEATING_WATER = "electrical_booster_heating_water"
 

--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -63,6 +63,7 @@ from .const import (
     ACTUAL_TEMPERATURE_WATER,
     COMPRESSOR_HEATING,
     COMPRESSOR_HEATING_WATER,
+    COMPRESSOR_SPEED,
     COMPRESSOR_STARTS,
     CONSUMED_HEATING,
     CONSUMED_HEATING_TODAY,
@@ -153,6 +154,7 @@ class StiebelEltronSensorEntityDescription(SensorEntityDescription):
     """Entity description for stiebel eltron with modbus register."""
 
     modbus_register: IsgRegisters
+    scale_factor: float = 1.0
 
 
 def create_temperature_entity_description(name, key, modbus_register: IsgRegisters):
@@ -898,6 +900,17 @@ LWZ_COMPRESSOR_SENSOR_TYPES = [
         state_class=SensorStateClass.MEASUREMENT,
         modbus_register=LwzEnergyDataRegisters.ELEC_BOOSTER_DHW,
     ),
+    StiebelEltronSensorEntityDescription(
+        key=COMPRESSOR_SPEED,
+        name="Compressor Frequency",
+        icon="mdi:sine-wave",
+        has_entity_name=True,
+        native_unit_of_measurement=UnitOfFrequency.HERTZ,
+        device_class=SensorDeviceClass.FREQUENCY,
+        state_class=SensorStateClass.MEASUREMENT,
+        modbus_register=LwzSystemValuesRegisters.COMPRESSOR_SPEED,
+        scale_factor=10.0,
+    ),
 ]
 
 LWZ_VENTILATION_SENSOR_TYPES = [
@@ -1044,7 +1057,10 @@ class StiebelEltronISGSensor(StiebelEltronISGEntity, SensorEntity):
             if error in (32768, 0):
                 return "no error"
             return f"error {error}"
-        return self.coordinator.get_register_value(self.modbus_register)
+        value = self.coordinator.get_register_value(self.modbus_register)
+        if value is not None and self.entity_description.scale_factor != 1.0:
+            return float(value) * self.entity_description.scale_factor
+        return value
 
 
 class StiebelEltronISGEnergySensor(StiebelEltronISGSensor):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -205,3 +205,23 @@ async def test_energy_data_lwz(hass: HomeAssistant, mock_modbus_lwz) -> None:
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.asyncio()
+async def test_compressor_frequency_lwz(hass: HomeAssistant, mock_modbus_lwz) -> None:
+    """Test compressor frequency sensor for lwz models."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test_lwz")
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    state = hass.states.get("sensor.stiebel_eltron_isg_compressor_frequency")
+    assert state is not None
+    assert state.state == "31.0"
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.NOT_LOADED


### PR DESCRIPTION
## Summary

- Adds `compressor_frequency` sensor for LWZ devices using `LwzSystemValuesRegisters.COMPRESSOR_SPEED` (address 32, System Values block)
- Adds optional `scale_factor` field to `StiebelEltronSensorEntityDescription` for register-specific scaling corrections
- `pystiebeleltron` applies ×0.1 to this register (data_type=2), but the register stores integer Hz — `scale_factor=10.0` corrects this
- Tested on Tecalor THZ 5.5 eco (= Stiebel Eltron LWZ 5 Plus)

## Test plan

- [x] `uv run ruff check .` — passed
- [x] `uv run ruff format .` — no changes
- [x] `uv run pytest -qq tests` — 9/9 passed
- [x] Deployed to live device, sensor shows correct Hz value when compressor is running

## Summary by Sourcery

Add a compressor frequency sensor for LWZ devices and introduce support for register-specific scaling of sensor values.

New Features:
- Expose a compressor frequency sensor for LWZ devices backed by the COMRESSOR_SPEED system value register.

Enhancements:
- Extend sensor entity descriptions with an optional scale factor to support per-register value scaling in the coordinator-backed sensors.

Tests:
- Add an integration-style test to validate the LWZ compressor frequency sensor is created and reports the expected scaled value.