### PR TITLE
Expose WPM compressor runtime-hour sensors (heating / DHW / cooling)

### DIFF
--- a/custom_components/stiebel_eltron_isg/const.py
+++ b/custom_components/stiebel_eltron_isg/const.py
@@ -128,6 +128,7 @@ CURRENT_POWER_CONSUMPTION = "current_power_consumption"
 COMPRESSOR_STARTS = "compressor_starts"
 COMPRESSOR_HEATING = "compressor_heating"
 COMPRESSOR_HEATING_WATER = "compressor_heating_water"
+COOLING_RUNTIME = "cooling_runtime"
 ELECTRICAL_BOOSTER_HEATING = "electrical_booster_heating"
 ELECTRICAL_BOOSTER_HEATING_WATER = "electrical_booster_heating_water"
 

--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -53,6 +53,7 @@ from .const import (
     CONSUMED_WATER_HEATING,
     CONSUMED_WATER_HEATING_TODAY,
     CONSUMED_WATER_HEATING_TOTAL,
+    COOLING_RUNTIME,
     DEWPOINT_TEMPERATURE,
     DEWPOINT_TEMPERATURE_HK1,
     DEWPOINT_TEMPERATURE_HK2,
@@ -1107,14 +1108,49 @@ LWZ_VENTILATION_SENSOR_TYPES = [
 ]
 
 
+WPM_COMPRESSOR_SENSOR_TYPES = [
+    StiebelEltronSensorEntityDescription(
+        key=COMPRESSOR_HEATING,
+        translation_key=COMPRESSOR_HEATING,
+        icon="mdi:hours-24",
+        native_unit_of_measurement="h",
+        state_class=SensorStateClass.MEASUREMENT,
+        modbus_register=lambda api: api.energy_data.vd_heating,
+    ),
+    StiebelEltronSensorEntityDescription(
+        key=COMPRESSOR_HEATING_WATER,
+        translation_key=COMPRESSOR_HEATING_WATER,
+        icon="mdi:hours-24",
+        native_unit_of_measurement="h",
+        state_class=SensorStateClass.MEASUREMENT,
+        modbus_register=lambda api: api.energy_data.vd_dhw,
+    ),
+    StiebelEltronSensorEntityDescription(
+        # Firmware register "VD KÜHLEN". On brine/ground-source systems cooling
+        # is passive (no compressor runs), so this counts cooling operation
+        # hours rather than compressor hours - hence the neutral name.
+        key=COOLING_RUNTIME,
+        translation_key=COOLING_RUNTIME,
+        icon="mdi:hours-24",
+        native_unit_of_measurement="h",
+        state_class=SensorStateClass.MEASUREMENT,
+        modbus_register=lambda api: api.energy_data.vd_cooling,
+    ),
+]
+
+
 WPM_3I_SENSOR_TYPES = (
     WPM_3I_SYSTEM_VALUES_SENSOR_TYPES
     + ENERGYMANAGEMENT_SENSOR_TYPES
     + ENERGY_SENSOR_TYPES
+    + WPM_COMPRESSOR_SENSOR_TYPES
 )
 
 WPM_SENSOR_TYPES = (
-    SYSTEM_VALUES_SENSOR_TYPES + ENERGYMANAGEMENT_SENSOR_TYPES + ENERGY_SENSOR_TYPES
+    SYSTEM_VALUES_SENSOR_TYPES
+    + ENERGYMANAGEMENT_SENSOR_TYPES
+    + ENERGY_SENSOR_TYPES
+    + WPM_COMPRESSOR_SENSOR_TYPES
 )
 
 LWZ_SENSOR_TYPES = (

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -314,6 +314,9 @@
             "compressor_heating_water": {
                 "name": "Compressor Heating Water"
             },
+            "cooling_runtime": {
+                "name": "Cooling Runtime"
+            },
             "electrical_booster_heating": {
                 "name": "Electrical Booster Heating"
             },

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -314,6 +314,9 @@
             "compressor_heating_water": {
                 "name": "Verdichter Warmwasser"
             },
+            "cooling_runtime": {
+                "name": "Kühlbetrieb Laufzeit"
+            },
             "electrical_booster_heating": {
                 "name": "Elektroheizung Heizung"
             },

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -303,6 +303,9 @@
             "compressor_heating_water": {
                 "name": "Compressor Heating Water"
             },
+            "cooling_runtime": {
+                "name": "Cooling Runtime"
+            },
             "electrical_booster_heating": {
                 "name": "Electrical Booster Heating"
             },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,42 @@
+"""Tests for the sensor platform."""
+
+from types import SimpleNamespace
+
+from custom_components.stiebel_eltron_isg.const import (
+    COMPRESSOR_HEATING,
+    COMPRESSOR_HEATING_WATER,
+    COOLING_RUNTIME,
+)
+from custom_components.stiebel_eltron_isg.sensor import (
+    WPM_3I_SENSOR_TYPES,
+    WPM_SENSOR_TYPES,
+)
+
+
+def _wpm(key: str):
+    return next(d for d in WPM_SENSOR_TYPES if d.key == key)
+
+
+def test_wpm_exposes_compressor_runtime_hours() -> None:
+    """WPM compressor runtime-hour sensors read vd_heating/vd_dhw/vd_cooling."""
+    api = SimpleNamespace(
+        energy_data=SimpleNamespace(vd_heating=2789, vd_dhw=1305, vd_cooling=9794)
+    )
+
+    heating = _wpm(COMPRESSOR_HEATING)
+    assert heating.modbus_register(api) == 2789
+    assert heating.native_unit_of_measurement == "h"
+
+    water = _wpm(COMPRESSOR_HEATING_WATER)
+    assert water.modbus_register(api) == 1305
+    assert water.native_unit_of_measurement == "h"
+
+    cooling = _wpm(COOLING_RUNTIME)
+    assert cooling.modbus_register(api) == 9794
+    assert cooling.native_unit_of_measurement == "h"
+
+
+def test_wpm_3i_exposes_compressor_runtime_hours() -> None:
+    """WPM_3i shares the vd_heating/vd_dhw/vd_cooling registers (3516-3518)."""
+    keys = {d.key for d in WPM_3I_SENSOR_TYPES}
+    assert {COMPRESSOR_HEATING, COMPRESSOR_HEATING_WATER, COOLING_RUNTIME} <= keys


### PR DESCRIPTION
## What

Exposes the compressor operating-hour counters for **WPM** controllers, which were previously only available on LWZ.

| Sensor | Field | Register | Live value* |
|---|---|---|---|
| Compressor Heating | `energy_data.vd_heating` | 3516 | 2789 h |
| Compressor Heating Water | `energy_data.vd_dhw` | 3517 | 1305 h |
| Cooling Runtime | `energy_data.vd_cooling` | 3518 | 9794 h |

\* verified read-only against a live WPM 3i and cross-checked one-to-one against its ISG Servicewelt (VD HEIZEN / VD WARMWASSER / VD KÜHLEN).

## Why "Cooling Runtime" and not "Compressor Cooling"

The cooling counter is named deliberately neutrally. On brine / ground-source systems cooling is **passive** - the source pump and heating-circuit pump run, the compressor does not - so the firmware's `VD KÜHLEN` register counts cooling *operation* hours, not compressor hours. On air-source systems the compressor does cool. "Cooling Runtime" is correct for both; "Compressor Cooling" would be wrong on ground-source units.

## Tests

`tests/test_sensor.py`: the three WPM sensors resolve to `vd_heating` / `vd_dhw` / `vd_cooling` with unit `h`.

All green; `ruff check` / `ruff format` clean. Includes `strings` / `en` / `de` translations.

Rebased onto the current `main` and reimplemented against the accessor-based API.
