### PR TITLE
Add WPM cooling flow-temperature hysteresis number entities

### DIFF
--- a/custom_components/stiebel_eltron_isg/const.py
+++ b/custom_components/stiebel_eltron_isg/const.py
@@ -222,8 +222,10 @@ DUALMODE_TEMPERATURE_WW = "dualmode_temperature_ww"
 
 AREA_COOLING_TARGET_ROOM_TEMPERATURE = "area_cooling_target_room_temperature"
 AREA_COOLING_TARGET_FLOW_TEMPERATURE = "area_cooling_target_flow_temperature"
+AREA_COOLING_FLOW_TEMPERATURE_HYSTERESIS = "area_cooling_flow_temperature_hysteresis"
 FAN_COOLING_TARGET_ROOM_TEMPERATURE = "fan_cooling_target_room_temperature"
 FAN_COOLING_TARGET_FLOW_TEMPERATURE = "fan_cooling_target_flow_temperature"
+FAN_COOLING_FLOW_TEMPERATURE_HYSTERESIS = "fan_cooling_flow_temperature_hysteresis"
 
 FAN_LEVEL_DAY = "fan_level_comfort"
 FAN_LEVEL_NIGHT = "fan_level_eco"

--- a/custom_components/stiebel_eltron_isg/number.py
+++ b/custom_components/stiebel_eltron_isg/number.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
+    AREA_COOLING_FLOW_TEMPERATURE_HYSTERESIS,
     AREA_COOLING_TARGET_FLOW_TEMPERATURE,
     AREA_COOLING_TARGET_ROOM_TEMPERATURE,
     COMFORT_COOLING_TEMPERATURE_TARGET_HK1,
@@ -28,6 +29,7 @@ from .const import (
     ECO_TEMPERATURE_TARGET_HK2,
     ECO_TEMPERATURE_TARGET_HK3,
     ECO_WATER_TEMPERATURE_TARGET,
+    FAN_COOLING_FLOW_TEMPERATURE_HYSTERESIS,
     FAN_COOLING_TARGET_FLOW_TEMPERATURE,
     FAN_COOLING_TARGET_ROOM_TEMPERATURE,
     FAN_LEVEL_DAY,
@@ -196,6 +198,17 @@ NUMBER_TYPES_WPM = [
         write_field="set_flow_temperature_area",
     ),
     StiebelEltronNumberEntityDescription(
+        key=AREA_COOLING_FLOW_TEMPERATURE_HYSTERESIS,
+        translation_key=AREA_COOLING_FLOW_TEMPERATURE_HYSTERESIS,
+        native_unit_of_measurement=UnitOfTemperature.KELVIN,
+        icon="mdi:thermometer-lines",
+        native_min_value=1,
+        native_max_value=5,
+        native_step=0.1,
+        modbus_register=lambda api: api.system_parameters.flow_temp_hysteresis_area,
+        write_field="flow_temp_hysteresis_area",
+    ),
+    StiebelEltronNumberEntityDescription(
         key=FAN_COOLING_TARGET_ROOM_TEMPERATURE,
         translation_key=FAN_COOLING_TARGET_ROOM_TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -216,6 +229,17 @@ NUMBER_TYPES_WPM = [
         native_step=0.1,
         modbus_register=lambda api: api.system_parameters.set_flow_temperature_fan,
         write_field="set_flow_temperature_fan",
+    ),
+    StiebelEltronNumberEntityDescription(
+        key=FAN_COOLING_FLOW_TEMPERATURE_HYSTERESIS,
+        translation_key=FAN_COOLING_FLOW_TEMPERATURE_HYSTERESIS,
+        native_unit_of_measurement=UnitOfTemperature.KELVIN,
+        icon="mdi:thermometer-lines",
+        native_min_value=1,
+        native_max_value=5,
+        native_step=0.1,
+        modbus_register=lambda api: api.system_parameters.flow_temp_hysteresis_fan,
+        write_field="flow_temp_hysteresis_fan",
     ),
     StiebelEltronNumberEntityDescription(
         key=HEATING_CURVE_RISE_HK1,

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -549,11 +549,17 @@
             "area_cooling_target_flow_temperature": {
                 "name": "Area Cooling Flow Temperature Target"
             },
+            "area_cooling_flow_temperature_hysteresis": {
+                "name": "Area Cooling Flow Temperature Hysteresis"
+            },
             "fan_cooling_target_room_temperature": {
                 "name": "Fan Cooling Room Temperature Target"
             },
             "fan_cooling_target_flow_temperature": {
                 "name": "Fan Cooling Flow Temperature Target"
+            },
+            "fan_cooling_flow_temperature_hysteresis": {
+                "name": "Fan Cooling Flow Temperature Hysteresis"
             },
             "heating_curve_rise_hk1": {
                 "name": "Heating Curve Rise HK1"

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -549,11 +549,17 @@
             "area_cooling_target_flow_temperature": {
                 "name": "Flächenkühlung Vorlauftemperatur Soll"
             },
+            "area_cooling_flow_temperature_hysteresis": {
+                "name": "Flächenkühlung Vorlauftemperatur Hysterese"
+            },
             "fan_cooling_target_room_temperature": {
                 "name": "Gebläsekühlung Raumtemperatur Soll"
             },
             "fan_cooling_target_flow_temperature": {
                 "name": "Gebläsekühlung Vorlauftemperatur Soll"
+            },
+            "fan_cooling_flow_temperature_hysteresis": {
+                "name": "Gebläsekühlung Vorlauftemperatur Hysterese"
             },
             "heating_curve_rise_hk1": {
                 "name": "Heizkurve Steilheit HK 1"

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -538,11 +538,17 @@
             "area_cooling_target_flow_temperature": {
                 "name": "Area Cooling Flow Temperature Target"
             },
+            "area_cooling_flow_temperature_hysteresis": {
+                "name": "Area Cooling Flow Temperature Hysteresis"
+            },
             "fan_cooling_target_room_temperature": {
                 "name": "Fan Cooling Room Temperature Target"
             },
             "fan_cooling_target_flow_temperature": {
                 "name": "Fan Cooling Flow Temperature Target"
+            },
+            "fan_cooling_flow_temperature_hysteresis": {
+                "name": "Fan Cooling Flow Temperature Hysteresis"
             },
             "heating_curve_rise_hk1": {
                 "name": "Heating Curve Rise HK1"

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,6 +1,15 @@
 """Tests for the number platform."""
 
-from custom_components.stiebel_eltron_isg.number import StiebelEltronISGNumberEntity
+from types import SimpleNamespace
+
+from custom_components.stiebel_eltron_isg.const import (
+    AREA_COOLING_FLOW_TEMPERATURE_HYSTERESIS,
+    FAN_COOLING_FLOW_TEMPERATURE_HYSTERESIS,
+)
+from custom_components.stiebel_eltron_isg.number import (
+    NUMBER_TYPES_WPM,
+    StiebelEltronISGNumberEntity,
+)
 
 
 class _StubCoordinator:
@@ -80,3 +89,31 @@ async def test_number_without_write_field_does_not_write() -> None:
     await entity.async_set_native_value(12.0)
 
     assert entity.coordinator.writes == []
+
+
+def _description(key: str):
+    return next(d for d in NUMBER_TYPES_WPM if d.key == key)
+
+
+def test_area_cooling_hysteresis_number_is_wired() -> None:
+    """The area cooling flow-temperature hysteresis number reads/writes 1514."""
+    description = _description(AREA_COOLING_FLOW_TEMPERATURE_HYSTERESIS)
+
+    api = SimpleNamespace(
+        system_parameters=SimpleNamespace(flow_temp_hysteresis_area=3.0)
+    )
+    assert description.modbus_register(api) == 3.0
+    assert description.write_field == "flow_temp_hysteresis_area"
+    assert (description.native_min_value, description.native_max_value) == (1, 5)
+
+
+def test_fan_cooling_hysteresis_number_is_wired() -> None:
+    """The fan cooling flow-temperature hysteresis number reads/writes 1517."""
+    description = _description(FAN_COOLING_FLOW_TEMPERATURE_HYSTERESIS)
+
+    api = SimpleNamespace(
+        system_parameters=SimpleNamespace(flow_temp_hysteresis_fan=2.5)
+    )
+    assert description.modbus_register(api) == 2.5
+    assert description.write_field == "flow_temp_hysteresis_fan"
+    assert (description.native_min_value, description.native_max_value) == (1, 5)


### PR DESCRIPTION
## What

Adds two writable `number` entities for the WPM cooling flow-temperature hysteresis, alongside the existing cooling flow/room targets:

| Entity | Field | Register |
|---|---|---|
| Area Cooling Flow Temperature Hysteresis | `system_parameters.flow_temp_hysteresis_area` | 1514 |
| Fan Cooling Flow Temperature Hysteresis | `system_parameters.flow_temp_hysteresis_fan` | 1517 |

Both are in Kelvin with a 1-5 K range, matching the controller's writable range.

## Notes

Rebased onto the current `main` and ported to the accessor-based API (`modbus_register` lambdas + `write_field`). Includes `strings` / `en` / `de` translations and a unit test asserting both entities resolve to the correct register accessor and write field.

All green; `ruff check` / `ruff format` clean.

## Known firmware limitation

As reported by @Padanian, on the controller firmware the area and fan cooling algorithms interact (area cooling can affect fan cooling operation). This is device-firmware behaviour, outside the scope of this integration - the PR only makes the existing hysteresis parameters writable.

## Note: the fan hysteresis is model-dependent

The fan variant (`flow_temp_hysteresis_fan`, holding register 1517) is only populated on systems that actually have fan-coil cooling. On units without it the register reads the unavailable sentinel, so that entity will show as `unavailable` there (confirmed read-only against a live WPM 3i: 1517 = unavailable while the area register 1514 = a real value). The area entity works everywhere with area cooling; the fan entity is only meaningful on fan-cooling units.
