### PR TITLE
Fix LWZ climate eco/night fan stage never being used

### DIFF
--- a/custom_components/stiebel_eltron_isg/climate.py
+++ b/custom_components/stiebel_eltron_isg/climate.py
@@ -19,7 +19,7 @@ from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, OPERATION_MODE
+from .const import DOMAIN
 from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
 from .entity import StiebelEltronISGEntity
 
@@ -489,7 +489,7 @@ class StiebelEltronLWZClimateEntity(StiebelEltronISGClimateEntity):
     @property
     def fan_mode(self) -> str | None:
         """Return the fan setting. Requires ClimateEntityFeature.FAN_MODE."""
-        if self.coordinator.data.get(OPERATION_MODE) == ECO_MODE:
+        if self.operation_mode == ECO_MODE:
             value = self._read_register(lambda api: api.system_parameters.night_stage)
             if value is None:
                 return None
@@ -503,7 +503,7 @@ class StiebelEltronLWZClimateEntity(StiebelEltronISGClimateEntity):
         """Set new target fan mode."""
         new_mode = HA_TO_LWZ_FAN.get(fan_mode)
         if new_mode is not None:
-            if self.coordinator.data.get(OPERATION_MODE) == ECO_MODE:
+            if self.operation_mode == ECO_MODE:
                 await self._write_field("night_stage", new_mode)
             else:
                 await self._write_field("day_stage", new_mode)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -2,7 +2,13 @@
 
 from types import SimpleNamespace
 
-from custom_components.stiebel_eltron_isg.climate import StiebelEltronWPMClimateEntity
+from homeassistant.components.climate.const import FAN_HIGH, FAN_LOW
+
+from custom_components.stiebel_eltron_isg.climate import (
+    ECO_MODE,
+    StiebelEltronLWZClimateEntity,
+    StiebelEltronWPMClimateEntity,
+)
 
 
 def test_climate_unavailable_when_last_update_failed() -> None:
@@ -13,3 +19,75 @@ def test_climate_unavailable_when_last_update_failed() -> None:
     # last_update_success is False, so availability must short-circuit to False
     # without evaluating the (stale) target temperature.
     assert entity.available is False
+
+
+class _FakeSystemParameters:
+    def __init__(self, operating_mode, day_stage, night_stage) -> None:
+        self.operating_mode = operating_mode
+        self.day_stage = day_stage
+        self.night_stage = night_stage
+
+
+class _FakeApi:
+    def __init__(self, system_parameters) -> None:
+        self.system_parameters = system_parameters
+
+
+class _StubCoordinator:
+    """Coordinator stub that resolves lambda accessors against a fake API."""
+
+    def __init__(self, api) -> None:
+        self._api = api
+        self.writes: list[tuple] = []
+        # The real DataUpdateCoordinator caches nothing of its own; ``data`` is
+        # an empty dict. The old code queried it with a string key and always
+        # missed, which is exactly the bug under test.
+        self.data: dict = {}
+
+    def get_value(self, accessor):
+        return accessor(self._api)
+
+    async def write_component_value(self, component, field, value) -> None:
+        self.writes.append((component, field, value))
+
+
+def _make_lwz_climate(
+    operating_mode: int, day_stage: int = 3, night_stage: int = 1
+) -> StiebelEltronLWZClimateEntity:
+    entity = StiebelEltronLWZClimateEntity.__new__(StiebelEltronLWZClimateEntity)
+    api = _FakeApi(_FakeSystemParameters(operating_mode, day_stage, night_stage))
+    entity.coordinator = _StubCoordinator(api)
+    entity.write_component = "system_parameters"
+    return entity
+
+
+def test_lwz_fan_mode_uses_night_stage_when_eco() -> None:
+    """In eco mode the fan mode must reflect the night stage, not the day stage."""
+    entity = _make_lwz_climate(operating_mode=ECO_MODE, day_stage=3, night_stage=1)
+
+    assert entity.fan_mode == FAN_LOW
+
+
+def test_lwz_fan_mode_uses_day_stage_when_not_eco() -> None:
+    """Outside eco mode the fan mode must reflect the day stage."""
+    entity = _make_lwz_climate(operating_mode=3, day_stage=3, night_stage=1)
+
+    assert entity.fan_mode == FAN_HIGH
+
+
+async def test_lwz_set_fan_mode_writes_night_stage_when_eco() -> None:
+    """Setting the fan mode in eco mode must write the night stage field."""
+    entity = _make_lwz_climate(operating_mode=ECO_MODE)
+
+    await entity.async_set_fan_mode(FAN_LOW)
+
+    assert entity.coordinator.writes == [("system_parameters", "night_stage", 1)]
+
+
+async def test_lwz_set_fan_mode_writes_day_stage_when_not_eco() -> None:
+    """Setting the fan mode outside eco mode must write the day stage field."""
+    entity = _make_lwz_climate(operating_mode=3)
+
+    await entity.async_set_fan_mode(FAN_HIGH)
+
+    assert entity.coordinator.writes == [("system_parameters", "day_stage", 3)]


### PR DESCRIPTION
## What

Fixes #575 - the LWZ climate fan mode never uses the eco/night stage.

`StiebelEltronLWZClimateEntity.fan_mode` and `async_set_fan_mode` detected eco mode via `self.coordinator.data.get(OPERATION_MODE)` - a plain string key (`"operation_mode"`) against the coordinator's `data` dict, which is not keyed by that string and is empty in this architecture. The lookup always returned `None`, so the eco branch was never taken: in eco/night operation the **day** stage was read and written instead of the **night** stage.

## How

Use the existing `operation_mode` property (`self.operation_mode == ECO_MODE`), matching how `target_temperature` already distinguishes eco vs. comfort.

## Tests

`tests/test_climate.py`: LWZ fan mode reads/writes the night stage in eco mode and the day stage otherwise.

All green; `ruff check` / `ruff format` clean.

Fixes #575

---

*This PR originally also changed the model-551 classification; that part was dropped - 551 uses the WPM system registers, so it stays on the WPM path.*
