### PR TITLE
Mark entities unavailable when the last coordinator update failed

### DIFF
--- a/custom_components/stiebel_eltron_isg/climate.py
+++ b/custom_components/stiebel_eltron_isg/climate.py
@@ -311,7 +311,9 @@ class StiebelEltronISGClimateEntity(StiebelEltronISGEntity, ClimateEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self.target_temperature is not None
+        return (
+            self.coordinator.last_update_success and self.target_temperature is not None
+        )
 
     @property
     def operation_mode(self) -> int:

--- a/custom_components/stiebel_eltron_isg/entity.py
+++ b/custom_components/stiebel_eltron_isg/entity.py
@@ -33,5 +33,12 @@ class StiebelEltronISGEntity(CoordinatorEntity[StiebelEltronDataCoordinator]):
 
     @property
     def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.coordinator.has_value(self.modbus_register)
+        """Return True if entity is available.
+
+        An entity is only available when the most recent coordinator update
+        succeeded; otherwise a lost connection would keep reporting the last
+        cached register value as if it were current.
+        """
+        return self.coordinator.last_update_success and self.coordinator.has_value(
+            self.modbus_register
+        )

--- a/custom_components/stiebel_eltron_isg/switch.py
+++ b/custom_components/stiebel_eltron_isg/switch.py
@@ -171,13 +171,8 @@ class StiebelEltronISGSwitch(StiebelEltronISGEntity, SwitchEntity):
             SG_READY_INPUT_1,
             SG_READY_INPUT_2,
         ):
-            has_value = self.coordinator.has_value(self.modbus_register)
-
-            if not has_value:
-                _LOGGER.debug(
-                    "Switch %s should not be available because register %s is not available",
-                    self.entity_description.key,
-                    self.entity_description.key,
-                )
-            return True
+            # These writable switches stay operable even when the device does
+            # not report a read-back value, but must still go unavailable when
+            # the coordinator can no longer reach the device.
+            return self.coordinator.last_update_success
         return super().available

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,15 @@
+"""Tests for the climate platform."""
+
+from types import SimpleNamespace
+
+from custom_components.stiebel_eltron_isg.climate import StiebelEltronWPMClimateEntity
+
+
+def test_climate_unavailable_when_last_update_failed() -> None:
+    """A failed coordinator update must mark the climate entity unavailable."""
+    entity = StiebelEltronWPMClimateEntity.__new__(StiebelEltronWPMClimateEntity)
+    entity.coordinator = SimpleNamespace(last_update_success=False)
+
+    # last_update_success is False, so availability must short-circuit to False
+    # without evaluating the (stale) target temperature.
+    assert entity.available is False

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,34 @@
+"""Tests for the shared entity base class."""
+
+from custom_components.stiebel_eltron_isg.entity import StiebelEltronISGEntity
+
+
+class _StubCoordinator:
+    def __init__(self, last_update_success: bool, has_value: bool) -> None:
+        self.last_update_success = last_update_success
+        self._has_value = has_value
+
+    def has_value(self, register) -> bool:
+        return self._has_value
+
+
+def _make_entity(last_update_success: bool, has_value: bool) -> StiebelEltronISGEntity:
+    entity = StiebelEltronISGEntity.__new__(StiebelEltronISGEntity)
+    entity.coordinator = _StubCoordinator(last_update_success, has_value)
+    entity.modbus_register = lambda api: None
+    return entity
+
+
+def test_available_when_update_succeeded_and_value_present() -> None:
+    """An entity is available when the last update succeeded and it has a value."""
+    assert _make_entity(last_update_success=True, has_value=True).available is True
+
+
+def test_unavailable_when_last_update_failed() -> None:
+    """A failed update must mark the entity unavailable, not show a stale value."""
+    assert _make_entity(last_update_success=False, has_value=True).available is False
+
+
+def test_unavailable_when_value_missing() -> None:
+    """A missing register value keeps the entity unavailable."""
+    assert _make_entity(last_update_success=True, has_value=False).available is False

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,27 @@
+"""Tests for the switch platform."""
+
+from types import SimpleNamespace
+
+from custom_components.stiebel_eltron_isg.const import CIRCULATION_PUMP
+from custom_components.stiebel_eltron_isg.switch import StiebelEltronISGSwitch
+
+
+def _make_switch(key: str, last_update_success: bool) -> StiebelEltronISGSwitch:
+    entity = StiebelEltronISGSwitch.__new__(StiebelEltronISGSwitch)
+    entity.entity_description = SimpleNamespace(key=key)
+    entity.coordinator = SimpleNamespace(last_update_success=last_update_success)
+    return entity
+
+
+def test_circulation_pump_switch_unavailable_when_last_update_failed() -> None:
+    """The always-on switches must still go unavailable on a failed update."""
+    entity = _make_switch(CIRCULATION_PUMP, last_update_success=False)
+
+    assert entity.available is False
+
+
+def test_circulation_pump_switch_available_when_update_succeeded() -> None:
+    """With a successful update the switch stays available."""
+    entity = _make_switch(CIRCULATION_PUMP, last_update_success=True)
+
+    assert entity.available is True


### PR DESCRIPTION
## What

Addresses the stale-data symptom of #540.

Entity availability was derived purely from whether the API client had a cached register value (`coordinator.has_value(...)`). After a lost connection or a failed modbus update the cached values persist, so sensors, climate and switches kept reporting the last readings as if they were current, instead of going `unavailable`.

## How

Require `coordinator.last_update_success` in:

- the base entity's `available` (covers sensor, binary_sensor, number, select),
- `StiebelEltronISGClimateEntity.available`,
- the circulation-pump / SG-Ready-input switch override that previously returned `True` unconditionally.

`SG_READY_ACTIVE` (which has a read-back value) already uses the base logic. The reset button stays always-available by design, since it is an action that does not depend on cached register data.

## Tests

`tests/test_entity.py`, `tests/test_climate.py`, `tests/test_switch.py`: an entity is unavailable when the last coordinator update failed, and available when it succeeded and has a value.

All green; `ruff check` and `ruff format` clean.

Relates to #540

## Summary by Sourcery

Mark entities unavailable when the coordinator’s last update failed to avoid exposing stale register values.

New Features:
- Apply coordinator last_update_success to base entity availability so entities only report values after successful updates.
- Ensure climate entities report unavailable when the coordinator cannot successfully update, even if a target temperature is present.
- Make circulation-pump and SG-Ready input switches become unavailable when coordinator updates fail while remaining operable when updates succeed.

Tests:
- Add unit tests for the shared entity base class to cover availability based on last_update_success and presence of register values.
- Add switch tests verifying circulation-pump availability toggles with coordinator update success.
- Add climate tests verifying entities become unavailable when the coordinator’s last update fails.