### PR TITLE
Handle unknown controller models gracefully during setup

### DIFF
--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -8,10 +8,14 @@ import logging
 
 from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from modbus_connection import ModbusError
 from modbus_connection.pymodbus import connect_tcp
-from pystiebeleltron import StiebelEltronModbusError, get_controller_model
+from pystiebeleltron import (
+    StiebelEltronModbusError,
+    UnknownControllerModelError,
+    get_controller_model,
+)
 
 from .const import DEFAULT_PORT, UNIT_ID
 from .coordinator import StiebelEltronConfigEntry
@@ -54,6 +58,14 @@ async def async_setup_entry(
         model = await get_controller_model(connection.for_unit(UNIT_ID))
     except StiebelEltronModbusError as exception:
         raise ConfigEntryNotReady("Could not read controller model") from exception
+    except UnknownControllerModelError as exception:
+        # An unrecognised controller id is a permanent condition, not a
+        # transient modbus glitch: fail cleanly instead of retrying forever.
+        # Adding support requires a pystiebeleltron update, which reloads the
+        # entry anyway.
+        raise ConfigEntryError(
+            f"Unsupported controller model: {exception}"
+        ) from exception
 
     coordinator = (
         StiebelEltronModbusWPMDataCoordinator(hass, entry, model, connection, host)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,7 +7,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from modbus_connection import ModbusError, ModbusTimeoutError
 from modbus_connection.mock import MockModbusConnection
-from pystiebeleltron import StiebelEltronModbusError
+from pystiebeleltron import StiebelEltronModbusError, UnknownControllerModelError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.stiebel_eltron_isg.const import DOMAIN
@@ -89,6 +89,21 @@ async def test_async_setup_entry_modbus_error(
 
     assert result is False
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_async_setup_entry_unknown_model(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_get_controller_model: MagicMock,
+) -> None:
+    """Setup fails cleanly (no retry) when the controller model is unknown."""
+    mock_config_entry.add_to_hass(hass)
+    mock_get_controller_model.side_effect = UnknownControllerModelError(165)
+
+    result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert result is False
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_async_setup_entry_coordinator_update_fails(


### PR DESCRIPTION
## What

Improves the failure mode reported in #397 - an unknown controller model crashed setup with an unhandled traceback.

`get_controller_model()` raises `UnknownControllerModelError` for a controller id that `pystiebeleltron` does not recognise (e.g. the reported `165`). Setup only caught `StiebelEltronModbusError`, so the unknown-model case propagated as an unhandled exception.

## How

Catch `UnknownControllerModelError` and raise `ConfigEntryError` with a clear message. An unrecognised controller id is a permanent condition, not a transient modbus glitch, so setup fails cleanly instead of retrying forever.

## Scope

This makes the failure clean and understandable. It does **not** add support for any specific model - actually driving a new controller (e.g. id 165) additionally requires its register mappings in `pystiebeleltron`. Hence "Relates to" rather than "Fixes".

## Tests

`tests/test_init.py::test_async_setup_entry_unknown_model`: setup ends in `SETUP_ERROR` (a clean, handled failure) when the controller model is unknown.

All green; `ruff check` / `ruff format` clean.

Relates to #397
