### PR TITLE
Separate implementation for WPM 3i

### DIFF
--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -74,7 +74,12 @@ async def async_setup_entry(
         if model == ControllerModel.WPM_3i
         else (
             StiebelEltronModbusWPMDataCoordinator(hass, entry, model, connection, host)
-            if model.value >= 390
+            if model
+            in (
+                ControllerModel.WPMsystem,
+                ControllerModel.WPM_3,
+                ControllerModel.LWZ_R290,
+            )
             else StiebelEltronModbusLWZDataCoordinator(
                 hass,
                 entry,

--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from modbus_connection import ModbusError
 from modbus_connection.pymodbus import connect_tcp
 from pystiebeleltron import (
+    ControllerModel,
     StiebelEltronModbusError,
     UnknownControllerModelError,
     get_controller_model,
@@ -20,6 +21,7 @@ from pystiebeleltron import (
 from .const import DEFAULT_PORT, UNIT_ID
 from .coordinator import StiebelEltronConfigEntry
 from .lwz_coordinator import StiebelEltronModbusLWZDataCoordinator
+from .wpm3i_coordinator import StiebelEltronModbusWPM3iDataCoordinator
 from .wpm_coordinator import StiebelEltronModbusWPMDataCoordinator
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -68,14 +70,18 @@ async def async_setup_entry(
         ) from exception
 
     coordinator = (
-        StiebelEltronModbusWPMDataCoordinator(hass, entry, model, connection, host)
-        if model.value >= 390
-        else StiebelEltronModbusLWZDataCoordinator(
-            hass,
-            entry,
-            model,
-            connection,
-            host,
+        StiebelEltronModbusWPM3iDataCoordinator(hass, entry, model, connection, host)
+        if model == ControllerModel.WPM_3i
+        else (
+            StiebelEltronModbusWPMDataCoordinator(hass, entry, model, connection, host)
+            if model.value >= 390
+            else StiebelEltronModbusLWZDataCoordinator(
+                hass,
+                entry,
+                model,
+                connection,
+                host,
+            )
         )
     )
     entry.runtime_data = coordinator

--- a/custom_components/stiebel_eltron_isg/binary_sensor.py
+++ b/custom_components/stiebel_eltron_isg/binary_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from pystiebeleltron import ControllerModel
 
 from .const import (
     BUFFER_1_CHARGING_PUMP,
@@ -84,7 +85,7 @@ class StiebelEltronBinarySensorEntityDescription(BinarySensorEntityDescription):
     bit_number: int = 0
 
 
-WPM_BINARY_SENSOR_TYPES = [
+WPM_3I_BINARY_SENSOR_TYPES = [
     StiebelEltronBinarySensorEntityDescription(
         translation_key=PUMP_ON_HK1,
         key=PUMP_ON_HK1,
@@ -170,6 +171,11 @@ WPM_BINARY_SENSOR_TYPES = [
         modbus_register=lambda api: api.system_state.fault_status,
         bit_number=0,
     ),
+]
+
+
+WPM_BINARY_SENSOR_TYPES = [
+    *WPM_3I_BINARY_SENSOR_TYPES,
     StiebelEltronBinarySensorEntityDescription(
         translation_key=COOLING_MODE,
         key=COOLING_MODE,
@@ -400,6 +406,7 @@ WPM_BINARY_SENSOR_TYPES = [
     ),
 ]
 
+
 LWZ_BINARY_SENSOR_TYPES = [
     StiebelEltronBinarySensorEntityDescription(
         translation_key=SWITCHING_PROGRAM_ENABLED,
@@ -530,7 +537,16 @@ async def async_setup_entry(
     """Set up the binary_sensor platform."""
     coordinator = entry.runtime_data
 
-    if coordinator.is_wpm:
+    if coordinator.model == ControllerModel.WPM_3i:
+        entities = [
+            StiebelEltronISGBinarySensor(
+                coordinator,
+                entry,
+                description,
+            )
+            for description in WPM_3I_BINARY_SENSOR_TYPES
+        ]
+    elif coordinator.is_wpm:
         entities = [
             StiebelEltronISGBinarySensor(
                 coordinator,

--- a/custom_components/stiebel_eltron_isg/climate.py
+++ b/custom_components/stiebel_eltron_isg/climate.py
@@ -18,6 +18,7 @@ from homeassistant.components.climate.const import (
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from pystiebeleltron import ControllerModel
 
 from .const import DOMAIN, OPERATION_MODE
 from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
@@ -153,6 +154,26 @@ class StiebelEltronClimateEntityDescription(ClimateEntityDescription):
             raise TypeError("comfort_target_temp_register must be a lambda expression")
 
 
+WPM_3I_CLIMATE_TYPES = [
+    StiebelEltronClimateEntityDescription(
+        key=CLIMATE_HK_1,
+        translation_key=CLIMATE_HK_1,
+        humidity_modbus_register=[
+            lambda api: api.system_values.relative_humidity,
+        ],
+        actual_temperature_register=[
+            lambda api: api.system_values.actual_temperature_fe7,
+            lambda api: api.system_values.actual_temperature_fek,
+        ],
+        eco_target_temp_register=lambda api: api.system_parameters.eco_temperature_hk_1,
+        comfort_target_temp_register=lambda api: (
+            api.system_parameters.comfort_temperature_hk_1
+        ),
+        eco_target_temp_write_field="eco_temperature_hk_1",
+        comfort_target_temp_write_field="comfort_temperature_hk_1",
+    )
+]
+
 WPM_CLIMATE_TYPES = [
     StiebelEltronClimateEntityDescription(
         key=CLIMATE_HK_1,
@@ -246,11 +267,18 @@ async def async_setup_entry(
 ) -> None:
     """Set up the select platform."""
     coordinator = entry.runtime_data
-
-    if coordinator.is_wpm:
-        entities: list[
-            StiebelEltronWPMClimateEntity | StiebelEltronLWZClimateEntity
-        ] = [
+    entities: list[StiebelEltronWPMClimateEntity | StiebelEltronLWZClimateEntity] = []
+    if coordinator.model == ControllerModel.WPM_3i:
+        entities = [
+            StiebelEltronWPMClimateEntity(
+                coordinator,
+                entry,
+                description,
+            )
+            for description in WPM_3I_CLIMATE_TYPES
+        ]
+    elif coordinator.is_wpm:
+        entities = [
             StiebelEltronWPMClimateEntity(
                 coordinator,
                 entry,

--- a/custom_components/stiebel_eltron_isg/const.py
+++ b/custom_components/stiebel_eltron_isg/const.py
@@ -238,5 +238,3 @@ EXTRACT_AIR_HUMIDITY = "extract_air_humidity"
 RESET_HEATPUMP = "reset_heatpump"
 ACTIVE_ERROR = "active_error"
 ERROR_STATUS = "error_status"
-
-MODEL_ID = "model_id"

--- a/custom_components/stiebel_eltron_isg/coordinator.py
+++ b/custom_components/stiebel_eltron_isg/coordinator.py
@@ -93,9 +93,9 @@ class StiebelEltronDataCoordinator(DataUpdateCoordinator):
             return "LWZ"
         if self._model == ControllerModel.WPM_3:
             return "WPM 3"
-        if self._model == ControllerModel.WPM_3I:
+        if self._model == ControllerModel.WPM_3i:
             return "WPM 3i"
-        if self._model == ControllerModel.WPMSYSTEM:
+        if self._model == ControllerModel.WPMsystem:
             return "WPMsystem"
         if self._model == ControllerModel.LWZ_R290:
             return "LWZ R290"

--- a/custom_components/stiebel_eltron_isg/coordinator.py
+++ b/custom_components/stiebel_eltron_isg/coordinator.py
@@ -37,7 +37,7 @@ class StiebelEltronDataCoordinator(DataUpdateCoordinator):
         host: str,
     ) -> None:
         """Initialize the Modbus hub."""
-        self._model_id: int = 0
+        self._model: ControllerModel = model
         self._host = host
         self._connection = connection
 
@@ -80,19 +80,26 @@ class StiebelEltronDataCoordinator(DataUpdateCoordinator):
         return self._host
 
     @property
-    def model(self) -> str:
+    def model(self) -> ControllerModel:
         """Return the controller model of the Stiebel Eltron ISG."""
-        if self._model_id == 103:
+        return self._model
+
+    @property
+    def model_name(self) -> str:
+        """Return the name of the controller model of the Stiebel Eltron ISG."""
+        if self._model == ControllerModel.LWZ:
             return "LWA/LWZ"
-        if self._model_id == 104:
+        if self._model == ControllerModel.LWZ_x04_SOL:
             return "LWZ"
-        if self._model_id == 390:
+        if self._model == ControllerModel.WPM_3:
             return "WPM 3"
-        if self._model_id == 391:
+        if self._model == ControllerModel.WPM_3I:
             return "WPM 3i"
-        if self._model_id == 449:
+        if self._model == ControllerModel.WPMSYSTEM:
             return "WPMsystem"
-        return f"other model ({self._model_id})"
+        if self._model == ControllerModel.LWZ_R290:
+            return "LWZ R290"
+        return f"other model ({self._model})"
 
     @property
     def is_wpm(self) -> bool:

--- a/custom_components/stiebel_eltron_isg/coordinator.py
+++ b/custom_components/stiebel_eltron_isg/coordinator.py
@@ -104,7 +104,15 @@ class StiebelEltronDataCoordinator(DataUpdateCoordinator):
     @property
     def is_wpm(self) -> bool:
         """Check if heat pump controller is a wpm model."""
-        return self._model_id >= 390
+        return (
+            self._model
+            in {
+                ControllerModel.WPM_3,
+                ControllerModel.WPM_3i,
+                ControllerModel.WPMsystem,
+                ControllerModel.LWZ_R290,  # Although this is a LWZ model, it uses the WPM protocol, so treat it as a WPM model.
+            }
+        )
 
     async def async_reset_heatpump(self) -> None:
         """Reset the heat pump."""

--- a/custom_components/stiebel_eltron_isg/coordinator.py
+++ b/custom_components/stiebel_eltron_isg/coordinator.py
@@ -99,7 +99,8 @@ class StiebelEltronDataCoordinator(DataUpdateCoordinator):
             return "WPMsystem"
         if self._model == ControllerModel.LWZ_R290:
             return "LWZ R290"
-        return f"other model ({self._model})"
+        # Fall back to the enum name for a clear, readable representation
+        return f"other model ({self._model.name})"
 
     @property
     def is_wpm(self) -> bool:

--- a/custom_components/stiebel_eltron_isg/lwz_coordinator.py
+++ b/custom_components/stiebel_eltron_isg/lwz_coordinator.py
@@ -40,10 +40,6 @@ class StiebelEltronModbusLWZDataCoordinator(StiebelEltronDataCoordinator):
         """Time to update."""
         try:
             await self._api.async_update()
-            self._model_id = (
-                self._api.energy_system_information.controller_identification
-            ) or 0
-
         except ModbusError as exception:
             raise UpdateFailed(exception) from exception
         else:

--- a/custom_components/stiebel_eltron_isg/lwz_coordinator.py
+++ b/custom_components/stiebel_eltron_isg/lwz_coordinator.py
@@ -55,8 +55,7 @@ class StiebelEltronModbusLWZDataCoordinator(StiebelEltronDataCoordinator):
     ) -> float | int | None:
         """Return a value from a callable accessor."""
         try:
-            if self._api is not None:
-                value = value_reference(self._api)
+            value = value_reference(self._api)
         except StiebelEltronModbusError as err:
             _LOGGER.warning(
                 "Failed to get value from accessor %r: %s",
@@ -80,19 +79,17 @@ class StiebelEltronModbusLWZDataCoordinator(StiebelEltronDataCoordinator):
         value: int | float,
     ) -> None:
         """Write a value to a component field."""
-        if self._api is not None:
-            component_obj = getattr(self._api, component, None)
-            if component_obj is not None and hasattr(component_obj, field):
-                await component_obj.write(field, value)
+        component_obj = getattr(self._api, component, None)
+        if component_obj is not None and hasattr(component_obj, field):
+            await component_obj.write(field, value)
 
     async def async_reset_heatpump(self) -> None:
         """Reset the heat pump."""
         _LOGGER.debug("Reset the heat pump")
-        if self._api is not None:
-            await self._api.system_parameters.write(
-                "reset",
-                1,
-            )
+        await self._api.system_parameters.write(
+            "reset",
+            1,
+        )
 
     def get_raw_data(self) -> dict:
         """Return the raw data from the heat pump."""

--- a/custom_components/stiebel_eltron_isg/number.py
+++ b/custom_components/stiebel_eltron_isg/number.py
@@ -9,6 +9,7 @@ from homeassistant.components.number import NumberEntity, NumberEntityDescriptio
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from pystiebeleltron import ControllerModel
 
 from .const import (
     AREA_COOLING_TARGET_FLOW_TEMPERATURE,
@@ -62,7 +63,7 @@ class StiebelEltronNumberEntityDescription(NumberEntityDescription):
         raise TypeError("modbus_register must be a lambda expression")
 
 
-NUMBER_TYPES_WPM = [
+NUMBER_TYPES_WPM_3I = [
     StiebelEltronNumberEntityDescription(
         key=COMFORT_TEMPERATURE_TARGET_HK1,
         translation_key=COMFORT_TEMPERATURE_TARGET_HK1,
@@ -108,28 +109,6 @@ NUMBER_TYPES_WPM = [
         write_field="eco_temperature_hk_2",
     ),
     StiebelEltronNumberEntityDescription(
-        key=COMFORT_TEMPERATURE_TARGET_HK3,
-        translation_key=COMFORT_TEMPERATURE_TARGET_HK3,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        icon="mdi:thermometer-high",
-        native_min_value=5,
-        native_max_value=30,
-        native_step=0.1,
-        modbus_register=lambda api: api.system_parameters.comfort_temperature_hk_3,
-        write_field="comfort_temperature_hk_3",
-    ),
-    StiebelEltronNumberEntityDescription(
-        key=ECO_TEMPERATURE_TARGET_HK3,
-        translation_key=ECO_TEMPERATURE_TARGET_HK3,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        icon="mdi:thermometer-low",
-        native_min_value=5,
-        native_max_value=30,
-        native_step=0.1,
-        modbus_register=lambda api: api.system_parameters.eco_temperature_hk_3,
-        write_field="eco_temperature_hk_3",
-    ),
-    StiebelEltronNumberEntityDescription(
         key=DUALMODE_TEMPERATURE_HZG,
         translation_key=DUALMODE_TEMPERATURE_HZG,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -148,8 +127,8 @@ NUMBER_TYPES_WPM = [
         native_min_value=10,
         native_max_value=60,
         native_step=0.1,
-        modbus_register=lambda api: api.system_parameters.comfort_temperature,
-        write_field="comfort_temperature",
+        modbus_register=lambda api: api.system_parameters.comfort_temperature_dhw,
+        write_field="comfort_temperature_dhw",
     ),
     StiebelEltronNumberEntityDescription(
         key=ECO_WATER_TEMPERATURE_TARGET,
@@ -159,8 +138,8 @@ NUMBER_TYPES_WPM = [
         native_min_value=10,
         native_max_value=60,
         native_step=0.1,
-        modbus_register=lambda api: api.system_parameters.eco_temperature,
-        write_field="eco_temperature",
+        modbus_register=lambda api: api.system_parameters.eco_temperature_dhw,
+        write_field="eco_temperature_dhw",
     ),
     StiebelEltronNumberEntityDescription(
         key=DUALMODE_TEMPERATURE_WW,
@@ -236,6 +215,32 @@ NUMBER_TYPES_WPM = [
         native_step=0.01,
         modbus_register=lambda api: api.system_parameters.heating_curve_rise_hk_2,
         write_field="heating_curve_rise_hk_2",
+    ),
+]
+
+NUMBER_TYPES_WPM = [
+    *NUMBER_TYPES_WPM_3I,
+    StiebelEltronNumberEntityDescription(
+        key=COMFORT_TEMPERATURE_TARGET_HK3,
+        translation_key=COMFORT_TEMPERATURE_TARGET_HK3,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer-high",
+        native_min_value=5,
+        native_max_value=30,
+        native_step=0.1,
+        modbus_register=lambda api: api.system_parameters.comfort_temperature_hk_3,
+        write_field="comfort_temperature_hk_3",
+    ),
+    StiebelEltronNumberEntityDescription(
+        key=ECO_TEMPERATURE_TARGET_HK3,
+        translation_key=ECO_TEMPERATURE_TARGET_HK3,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermometer-low",
+        native_min_value=5,
+        native_max_value=30,
+        native_step=0.1,
+        modbus_register=lambda api: api.system_parameters.eco_temperature_hk_3,
+        write_field="eco_temperature_hk_3",
     ),
     StiebelEltronNumberEntityDescription(
         key=HEATING_CURVE_RISE_HK3,
@@ -442,7 +447,16 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     entities = []
-    if coordinator.is_wpm:
+    if coordinator.model == ControllerModel.WPM_3i:
+        entities = [
+            StiebelEltronISGNumberEntity(
+                coordinator,
+                entry,
+                description,
+            )
+            for description in NUMBER_TYPES_WPM_3I
+        ]
+    elif coordinator.is_wpm:
         entities = [
             StiebelEltronISGNumberEntity(
                 coordinator,

--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
+from pystiebeleltron import ControllerModel
 
 from .const import (
     ACTIVE_ERROR,
@@ -243,6 +244,131 @@ def create_volume_stream_entity_description(
         modbus_register=modbus_register,
     )
 
+
+WPM_3I_SYSTEM_VALUES_SENSOR_TYPES = [
+    create_temperature_entity_description(
+        "Actual Temperature",
+        ACTUAL_TEMPERATURE,
+        lambda api: api.system_values.actual_temperature_fe7,
+    ),
+    create_temperature_entity_description(
+        "Target Temperature",
+        TARGET_TEMPERATURE,
+        lambda api: api.system_values.set_temperature_fe7,
+    ),
+    create_temperature_entity_description(
+        "Actual Temperature FEK",
+        ACTUAL_TEMPERATURE_FEK,
+        lambda api: api.system_values.actual_temperature_fek,
+    ),
+    create_temperature_entity_description(
+        "Target Temperature FEK",
+        TARGET_TEMPERATURE_FEK,
+        lambda api: api.system_values.set_temperature_fek,
+    ),
+    create_humidity_entity_description(
+        "Humidity", ACTUAL_HUMIDITY, lambda api: api.system_values.relative_humidity
+    ),
+    create_temperature_entity_description(
+        "Dew Point Temperature",
+        DEWPOINT_TEMPERATURE,
+        lambda api: api.system_values.dew_point_temperature,
+    ),
+    create_temperature_entity_description(
+        "Outdoor Temperature",
+        OUTDOOR_TEMPERATURE,
+        lambda api: api.system_values.outside_temperature,
+    ),
+    create_temperature_entity_description(
+        "Target Temperature HK 1",
+        TARGET_TEMPERATURE_HK1,
+        lambda api: api.system_values.set_temperature_hk_1,
+    ),
+    create_temperature_entity_description(
+        "Actual Temperature HK 2",
+        ACTUAL_TEMPERATURE_HK2,
+        lambda api: api.system_values.actual_temperature_hk_2,
+    ),
+    create_temperature_entity_description(
+        "Target Temperature HK 2",
+        TARGET_TEMPERATURE_HK2,
+        lambda api: api.system_values.set_temperature_hk_2,
+    ),
+    create_temperature_entity_description(
+        "Flow Temperature WP",
+        FLOW_TEMPERATURE_WP,
+        lambda api: api.system_values.actual_flow_temperature_wp,
+    ),
+    create_temperature_entity_description(
+        "Flow Temperature NHZ",
+        FLOW_TEMPERATURE_NHZ,
+        lambda api: api.system_values.actual_flow_temperature_nhz,
+    ),
+    create_temperature_entity_description(
+        "Flow Temperature",
+        FLOW_TEMPERATURE,
+        lambda api: api.system_values.actual_flow_temperature,
+    ),
+    create_temperature_entity_description(
+        "Return Temperature",
+        RETURN_TEMPERATURE,
+        lambda api: api.system_values.actual_return_temperature,
+    ),
+    create_temperature_entity_description(
+        "Actual Temperature Buffer",
+        ACTUAL_TEMPERATURE_BUFFER,
+        lambda api: api.system_values.actual_buffer_temperature,
+    ),
+    create_temperature_entity_description(
+        "Target Temperature Buffer",
+        TARGET_TEMPERATURE_BUFFER,
+        lambda api: api.system_values.set_buffer_temperature,
+    ),
+    create_pressure_entity_description(
+        "Heater Pressure",
+        HEATER_PRESSURE,
+        lambda api: api.system_values.heating_pressure,
+    ),
+    create_volume_stream_entity_description(
+        "Volume Stream", VOLUME_STREAM, lambda api: api.system_values.flow_rate
+    ),
+    create_temperature_entity_description(
+        "Actual Temperature Water",
+        ACTUAL_TEMPERATURE_WATER,
+        lambda api: api.system_values.actual_temperature_dhw,
+    ),
+    create_temperature_entity_description(
+        "Target Temperature Water",
+        TARGET_TEMPERATURE_WATER,
+        lambda api: api.system_values.set_temperature_dhw,
+    ),
+    create_temperature_entity_description(
+        "Source Temperature",
+        SOURCE_TEMPERATURE,
+        lambda api: api.system_values.source_temperature,
+    ),
+    create_temperature_entity_description(
+        "Min Source Temperature",
+        MIN_SOURCE_TEMPERATURE,
+        lambda api: api.system_values.min_source_temperature,
+    ),
+    create_pressure_entity_description(
+        "Source Pressure",
+        SOURCE_PRESSURE,
+        lambda api: api.system_values.source_pressure,
+    ),
+    create_temperature_entity_description(
+        "Hot Gas Temperature",
+        HOT_GAS_TEMPERATURE,
+        lambda api: api.system_values.hot_gas_temperature,
+    ),
+    create_pressure_entity_description(
+        "High Pressure", HIGH_PRESSURE, lambda api: api.system_values.high_pressure
+    ),
+    create_pressure_entity_description(
+        "Low Pressure", LOW_PRESSURE, lambda api: api.system_values.low_pressure
+    ),
+]
 
 SYSTEM_VALUES_SENSOR_TYPES = [
     create_temperature_entity_description(
@@ -955,6 +1081,12 @@ LWZ_VENTILATION_SENSOR_TYPES = [
 ]
 
 
+WPM_3I_SENSOR_TYPES = (
+    WPM_3I_SYSTEM_VALUES_SENSOR_TYPES
+    + ENERGYMANAGEMENT_SENSOR_TYPES
+    + ENERGY_SENSOR_TYPES
+)
+
 WPM_SENSOR_TYPES = (
     SYSTEM_VALUES_SENSOR_TYPES + ENERGYMANAGEMENT_SENSOR_TYPES + ENERGY_SENSOR_TYPES
 )
@@ -976,7 +1108,25 @@ async def async_setup_entry(
     """Set up the sensor platform."""
     coordinator = entry.runtime_data
 
-    if coordinator.is_wpm:
+    if coordinator.model == ControllerModel.WPM_3i:
+        entities = [
+            StiebelEltronISGSensor(
+                coordinator,
+                entry,
+                description,
+            )
+            for description in WPM_3I_SENSOR_TYPES
+        ]
+        daily_energy_entities = [
+            StiebelEltronISGEnergySensor(
+                coordinator,
+                entry,
+                description,
+            )
+            for description in ENERGY_DAILY_SENSOR_TYPES
+        ]
+        entities.extend(daily_energy_entities)
+    elif coordinator.is_wpm:
         entities = [
             StiebelEltronISGSensor(
                 coordinator,

--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -280,6 +280,11 @@ WPM_3I_SYSTEM_VALUES_SENSOR_TYPES = [
         lambda api: api.system_values.outside_temperature,
     ),
     create_temperature_entity_description(
+        "Actual Temperature HK 1",
+        ACTUAL_TEMPERATURE_HK1,
+        lambda api: api.system_values.actual_temperature_hk_1,
+    ),
+    create_temperature_entity_description(
         "Target Temperature HK 1",
         TARGET_TEMPERATURE_HK1,
         lambda api: api.system_values.set_temperature_hk_1_wpm3i,

--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -348,6 +348,26 @@ WPM_3I_SYSTEM_VALUES_SENSOR_TYPES = [
         lambda api: api.system_values.set_temperature_dhw,
     ),
     create_temperature_entity_description(
+        "Actual Temperature Cooling Fancoil",
+        ACTUAL_TEMPERATURE_COOLING_FANCOIL,
+        lambda api: api.system_values.actual_temperature_fan,
+    ),
+    create_temperature_entity_description(
+        "Target Temperature Cooling Fancoil",
+        TARGET_TEMPERATURE_COOLING_FANCOIL,
+        lambda api: api.system_values.set_temperature_fan,
+    ),
+    create_temperature_entity_description(
+        "Actual Temperature Cooling Surface",
+        ACTUAL_TEMPERATURE_COOLING_SURFACE,
+        lambda api: api.system_values.actual_temperature_area,
+    ),
+    create_temperature_entity_description(
+        "Target Temperature Cooling Surface",
+        TARGET_TEMPERATURE_COOLING_SURFACE,
+        lambda api: api.system_values.set_temperature_area,
+    ),
+    create_temperature_entity_description(
         "Source Temperature",
         SOURCE_TEMPERATURE,
         lambda api: api.system_values.source_temperature,

--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -282,7 +282,7 @@ WPM_3I_SYSTEM_VALUES_SENSOR_TYPES = [
     create_temperature_entity_description(
         "Target Temperature HK 1",
         TARGET_TEMPERATURE_HK1,
-        lambda api: api.system_values.set_temperature_hk_1,
+        lambda api: api.system_values.set_temperature_hk_1_wpm3i,
     ),
     create_temperature_entity_description(
         "Actual Temperature HK 2",

--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -213,6 +213,7 @@ def create_humidity_entity_description(
         native_unit_of_measurement=PERCENTAGE,
         icon="mdi:water-percent",
         state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.HUMIDITY,
         modbus_register=modbus_register,
     )
 

--- a/custom_components/stiebel_eltron_isg/switch.py
+++ b/custom_components/stiebel_eltron_isg/switch.py
@@ -11,6 +11,7 @@ from homeassistant.components.switch import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from pystiebeleltron import ControllerModel
 
 from .const import (
     CIRCULATION_PUMP,
@@ -90,7 +91,7 @@ async def async_setup_entry(
         for description in SWITCH_TYPES
     ]
 
-    if coordinator.is_wpm:
+    if coordinator.model in (ControllerModel.LWZ_R290, ControllerModel.WPMsystem):
         # Add the circulation pump switch for WPM systems
         entities.append(
             StiebelEltronISGSwitch(

--- a/custom_components/stiebel_eltron_isg/wpm3i.py
+++ b/custom_components/stiebel_eltron_isg/wpm3i.py
@@ -237,8 +237,6 @@ class Wpm3iStiebelEltronAPI:
                 self.energy_data,
                 self.energy_management_settings,
                 self.energy_system_information,
-                self.energy_management_settings,
-                self.energy_system_information,
             ],
         )
 

--- a/custom_components/stiebel_eltron_isg/wpm3i.py
+++ b/custom_components/stiebel_eltron_isg/wpm3i.py
@@ -1,0 +1,247 @@
+"""Modbus api for stiebel eltron heat pumps. This file is generated. Do not modify it manually."""
+# ruff: noqa: D101, D102, D107
+
+from __future__ import annotations
+
+from modbus_connection import ModbusUnit
+from modbus_connection.model import Component, ComponentGroup, gauge, integer
+from pystiebeleltron import UNAVAILABLE, in_range, scaled_sum
+
+WPM3I_HOLDING_RANGES = ((1500, 1520), (4000, 4002))
+WPM3I_INPUT_RANGES = ((500, 540), (2500, 2506), (3500, 3521), (5000, 5001))
+
+
+class Wpm3iSystemValues(Component):
+    register_space = "input"
+    register_ranges = WPM3I_INPUT_RANGES
+
+    actual_temperature_fe7 = gauge(500, 0.1, nan=UNAVAILABLE, unit="°C")
+    set_temperature_fe7 = gauge(501, 0.1, nan=UNAVAILABLE, unit="°C")
+    actual_temperature_fek = gauge(502, 0.1, nan=UNAVAILABLE, unit="°C")
+    set_temperature_fek = gauge(503, 0.1, nan=UNAVAILABLE, unit="°C")
+    relative_humidity = gauge(504, 0.1, nan=UNAVAILABLE, unit="%")
+    dew_point_temperature = gauge(505, 0.1, nan=UNAVAILABLE, unit="°C")
+    outside_temperature = gauge(506, 0.1, nan=UNAVAILABLE, unit="°C")
+    actual_temperature_hk_1 = gauge(507, 0.1, nan=UNAVAILABLE, unit="°C")
+    set_temperature_hk_1_wpm3i = gauge(508, 0.1, nan=UNAVAILABLE, unit="°C")
+    actual_temperature_hk_2 = gauge(510, 0.1, nan=UNAVAILABLE, unit="°C")
+    set_temperature_hk_2 = gauge(511, 0.1, nan=UNAVAILABLE, unit="°C")
+    actual_flow_temperature_wp = gauge(512, 0.1, nan=UNAVAILABLE, unit="°C")
+    actual_flow_temperature_nhz = gauge(513, 0.1, nan=UNAVAILABLE, unit="°C")
+    actual_flow_temperature = gauge(514, 0.1, nan=UNAVAILABLE, unit="°C")
+    actual_return_temperature = gauge(515, 0.1, nan=UNAVAILABLE, unit="°C")
+    set_fixed_temperature = gauge(516, 0.1, nan=UNAVAILABLE, unit="°C")
+    actual_buffer_temperature = gauge(517, 0.1, nan=UNAVAILABLE, unit="°C")
+    set_buffer_temperature = gauge(518, 0.1, nan=UNAVAILABLE, unit="°C")
+    heating_pressure = gauge(519, 0.01, nan=UNAVAILABLE, unit="bar")
+    flow_rate = gauge(520, 0.01, nan=UNAVAILABLE, unit="l/min")
+    actual_temperature_dhw = gauge(521, 0.1, nan=UNAVAILABLE, unit="°C")
+    set_temperature_dhw = gauge(522, 0.1, nan=UNAVAILABLE, unit="°C")
+    actual_temperature_fan = gauge(523, 0.1, nan=UNAVAILABLE, unit="K")
+    set_temperature_fan = gauge(524, 0.1, nan=UNAVAILABLE, unit="K")
+    actual_temperature_area = gauge(525, 0.1, nan=UNAVAILABLE, unit="K")
+    set_temperature_area = gauge(526, 0.1, nan=UNAVAILABLE, unit="K")
+    application_limit_hzg = gauge(532, 0.1, nan=UNAVAILABLE, unit="°C")
+    application_limit_ww = gauge(533, 0.1, nan=UNAVAILABLE, unit="°C")
+    source_temperature = gauge(535, 0.1, nan=UNAVAILABLE, unit="°C")
+    min_source_temperature = gauge(536, 0.1, nan=UNAVAILABLE, unit="°C")
+    source_pressure = gauge(537, 0.01, nan=UNAVAILABLE, unit="bar")
+    hot_gas_temperature = gauge(538, 0.1, nan=UNAVAILABLE, unit="°C")
+    high_pressure = gauge(539, 0.1, nan=UNAVAILABLE, unit="bar")
+    low_pressure = gauge(540, 0.1, nan=UNAVAILABLE, unit="bar")
+
+
+class Wpm3iSystemParameters(Component):
+    register_space = "holding"
+    register_ranges = WPM3I_HOLDING_RANGES
+
+    operating_mode = integer(
+        1500, signed=False, nan=UNAVAILABLE, writable=in_range(0, 5)
+    )
+    comfort_temperature_hk_1 = gauge(
+        1501, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(5, 30)
+    )
+    eco_temperature_hk_1 = gauge(
+        1502, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(5, 30)
+    )
+    heating_curve_rise_hk_1 = gauge(
+        1503, 0.01, nan=UNAVAILABLE, writable=in_range(0, 3)
+    )
+    comfort_temperature_hk_2 = gauge(
+        1504, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(5, 30)
+    )
+    eco_temperature_hk_2 = gauge(
+        1505, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(5, 30)
+    )
+    heating_curve_rise_hk_2 = gauge(
+        1506, 0.01, nan=UNAVAILABLE, writable=in_range(0, 3)
+    )
+    fixed_value_operation = gauge(
+        1507, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(20, 70)
+    )
+    dual_mode_temp_hzg = gauge(
+        1508, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(-40, 40)
+    )
+    comfort_temperature = gauge(
+        1509, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(10, 60)
+    )
+    eco_temperature = gauge(
+        1510, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(10, 60)
+    )
+    dhw_stages = integer(1511, signed=False, nan=UNAVAILABLE, writable=in_range(0, 6))
+    dual_mode_temp_ww = gauge(
+        1512, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(-40, 40)
+    )
+    set_flow_temperature_area = gauge(
+        1513, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(7, 25)
+    )
+    flow_temp_hysteresis_area = gauge(
+        1514, 0.1, nan=UNAVAILABLE, unit="K", writable=in_range(1, 5)
+    )
+    set_room_temperature_area = gauge(
+        1515, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(20, 30)
+    )
+    set_flow_temperature_fan = gauge(
+        1516, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(7, 25)
+    )
+    flow_temp_hysteresis_fan = gauge(
+        1517, 0.1, nan=UNAVAILABLE, unit="K", writable=in_range(1, 5)
+    )
+    set_room_temperature_fan = gauge(
+        1518, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(20, 30)
+    )
+    reset = integer(1519, signed=False, nan=UNAVAILABLE, writable=in_range(1, 3))
+    restart_isg = integer(1520, signed=False, nan=UNAVAILABLE, writable=in_range(0, 2))
+
+
+class Wpm3iSystemState(Component):
+    register_space = "input"
+    register_ranges = WPM3I_INPUT_RANGES
+
+    operating_status = integer(2500, signed=False, nan=UNAVAILABLE)
+    power_off = integer(2501, signed=False, nan=UNAVAILABLE)
+    fault_status = integer(2503, signed=False, nan=UNAVAILABLE)
+    bus_status = integer(2504, signed=False, nan=UNAVAILABLE)
+    active_error = integer(2506, signed=False, nan=UNAVAILABLE)
+
+
+class Wpm3iEnergyData(Component):
+    register_space = "input"
+    register_ranges = WPM3I_INPUT_RANGES
+
+    vd_heating_day = integer(3500, signed=False, nan=UNAVAILABLE, unit="kWh")
+    vd_heating_total = scaled_sum(3501, (1, 1000), unit="kWh")
+    vd_dhw_day = integer(3503, signed=False, nan=UNAVAILABLE, unit="kWh")
+    vd_dhw_total = scaled_sum(3504, (1, 1000), unit="kWh")
+    nhz_heating_total = scaled_sum(3506, (1, 1000), unit="kWh")
+    nhz_dhw_total = scaled_sum(3508, (1, 1000), unit="kWh")
+    vd_heating_day_consumed = integer(3510, signed=False, nan=UNAVAILABLE, unit="kWh")
+    vd_heating_total_consumed = scaled_sum(3511, (1, 1000), unit="kWh")
+    vd_dhw_day_consumed = integer(3513, signed=False, nan=UNAVAILABLE, unit="kWh")
+    vd_dhw_total_consumed = scaled_sum(3514, (1, 1000), unit="kWh")
+    vd_heating = integer(3516, signed=False, nan=UNAVAILABLE, unit="h")
+    vd_dhw = integer(3517, signed=False, nan=UNAVAILABLE, unit="h")
+    vd_cooling = integer(3518, signed=False, nan=UNAVAILABLE, unit="h")
+    nhz_1 = integer(3519, signed=False, nan=UNAVAILABLE, unit="h")
+    nhz_2 = integer(3520, signed=False, nan=UNAVAILABLE, unit="h")
+    nhz_1_2 = integer(3521, signed=False, nan=UNAVAILABLE, unit="h")
+
+    _DAY_AND_TOTAL = (
+        ("vd_heating_day", "vd_heating_total", "vd_heating_day_and_total"),
+        ("vd_dhw_day", "vd_dhw_total", "vd_dhw_day_and_total"),
+        (
+            "vd_heating_day_consumed",
+            "vd_heating_total_consumed",
+            "vd_heating_day_and_total_consumed",
+        ),
+        (
+            "vd_dhw_day_consumed",
+            "vd_dhw_total_consumed",
+            "vd_dhw_day_and_total_consumed",
+        ),
+    )
+
+    def __init__(self, unit: ModbusUnit, index: int = 1) -> None:
+        super().__init__(unit, index)
+        self._running_totals: dict[str, int] = {}
+
+    def notify(self) -> None:
+        """Refresh the monotonic day-and-total counters, then notify listeners."""
+        for day_attr, total_attr, key in self._DAY_AND_TOTAL:
+            day = getattr(self, day_attr)
+            total = getattr(self, total_attr)
+            if day is not None and total is not None:
+                combined = day + total
+                previous = self._running_totals.get(key)
+                self._running_totals[key] = (
+                    combined if previous is None else max(combined, previous)
+                )
+        super().notify()
+
+    @property
+    def vd_heating_day_and_total(self) -> int | None:
+        return self._running_totals.get("vd_heating_day_and_total")
+
+    @property
+    def vd_dhw_day_and_total(self) -> int | None:
+        return self._running_totals.get("vd_dhw_day_and_total")
+
+    @property
+    def vd_heating_day_and_total_consumed(self) -> int | None:
+        return self._running_totals.get("vd_heating_day_and_total_consumed")
+
+    @property
+    def vd_dhw_day_and_total_consumed(self) -> int | None:
+        return self._running_totals.get("vd_dhw_day_and_total_consumed")
+
+
+class Wpm3iEnergyManagementSettings(Component):
+    register_space = "holding"
+    register_ranges = WPM3I_HOLDING_RANGES
+
+    switch_sg_ready_on_and_off = integer(
+        4000, signed=False, nan=UNAVAILABLE, writable=in_range(0, 1)
+    )
+    sg_ready_input_1 = integer(
+        4001, signed=False, nan=UNAVAILABLE, writable=in_range(0, 1)
+    )
+    sg_ready_input_2 = integer(
+        4002, signed=False, nan=UNAVAILABLE, writable=in_range(0, 1)
+    )
+
+
+class Wpm3iEnergySystemInformation(Component):
+    register_space = "input"
+    register_ranges = WPM3I_INPUT_RANGES
+
+    sg_ready_operating_state = integer(5000, signed=False, nan=UNAVAILABLE)
+    controller_identification = integer(5001, signed=False, nan=UNAVAILABLE)
+
+
+class Wpm3iStiebelEltronAPI:
+    """Stiebel Eltron heat pump API over a modbus_connection ModbusUnit."""
+
+    def __init__(self, unit: ModbusUnit) -> None:
+        self.system_values = Wpm3iSystemValues(unit)
+        self.system_parameters = Wpm3iSystemParameters(unit)
+        self.system_state = Wpm3iSystemState(unit)
+        self.energy_data = Wpm3iEnergyData(unit)
+        self.energy_management_settings = Wpm3iEnergyManagementSettings(unit)
+        self.energy_system_information = Wpm3iEnergySystemInformation(unit)
+        self._group = ComponentGroup(
+            unit,
+            [
+                self.system_values,
+                self.system_parameters,
+                self.system_state,
+                self.energy_data,
+                self.energy_management_settings,
+                self.energy_system_information,
+                self.energy_management_settings,
+                self.energy_system_information,
+            ],
+        )
+
+    async def async_update(self) -> None:
+        """Read every component in one pooled set of block reads."""
+        await self._group.async_update()

--- a/custom_components/stiebel_eltron_isg/wpm3i.py
+++ b/custom_components/stiebel_eltron_isg/wpm3i.py
@@ -82,10 +82,10 @@ class Wpm3iSystemParameters(Component):
     dual_mode_temp_hzg = gauge(
         1508, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(-40, 40)
     )
-    comfort_temperature = gauge(
+    comfort_temperature_dhw = gauge(
         1509, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(10, 60)
     )
-    eco_temperature = gauge(
+    eco_temperature_dhw = gauge(
         1510, 0.1, nan=UNAVAILABLE, unit="°C", writable=in_range(10, 60)
     )
     dhw_stages = integer(1511, signed=False, nan=UNAVAILABLE, writable=in_range(0, 6))

--- a/custom_components/stiebel_eltron_isg/wpm3i_coordinator.py
+++ b/custom_components/stiebel_eltron_isg/wpm3i_coordinator.py
@@ -42,10 +42,6 @@ class StiebelEltronModbusWPM3iDataCoordinator(StiebelEltronDataCoordinator):
         """Time to update."""
         try:
             await self._api.async_update()
-            self._model_id = (
-                self._api.energy_system_information.controller_identification
-            ) or 0
-
         except ModbusError as exception:
             raise UpdateFailed(exception) from exception
         else:

--- a/custom_components/stiebel_eltron_isg/wpm3i_coordinator.py
+++ b/custom_components/stiebel_eltron_isg/wpm3i_coordinator.py
@@ -1,0 +1,105 @@
+"""Data Coordinator for the WPM Stiebel Eltron heat pumps.
+
+For more details about this integration, please refer to
+https://github.com/pail23/stiebel_eltron_isg
+"""
+
+from collections.abc import Callable
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from modbus_connection import ModbusConnection
+from modbus_connection.cli_helper import field_rows
+from pystiebeleltron import ControllerModel, ModbusError, StiebelEltronModbusError
+
+from custom_components.stiebel_eltron_isg.const import UNIT_ID
+
+from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
+from .wpm3i import Wpm3iStiebelEltronAPI
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+
+class StiebelEltronModbusWPM3iDataCoordinator(StiebelEltronDataCoordinator):
+    """Communicates with WPM Controllers."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: StiebelEltronConfigEntry,
+        model: ControllerModel,
+        connection: ModbusConnection,
+        host: str,
+    ) -> None:
+        """Initialize the Modbus hub."""
+        self._api = Wpm3iStiebelEltronAPI(connection.for_unit(UNIT_ID))
+
+        super().__init__(hass, entry, model, connection, host)
+
+    async def _async_update_data(self) -> dict[Any, float | int | None]:
+        """Time to update."""
+        try:
+            await self._api.async_update()
+            self._model_id = (
+                self._api.energy_system_information.controller_identification
+            ) or 0
+
+        except ModbusError as exception:
+            raise UpdateFailed(exception) from exception
+        else:
+            return {}
+
+    def get_value(
+        self,
+        value_reference: Callable[[Wpm3iStiebelEltronAPI], float | int | None],
+    ) -> float | int | None:
+        """Return a value from a callable accessor."""
+        try:
+            if self._api is not None:
+                value = value_reference(self._api)
+        except StiebelEltronModbusError as err:
+            _LOGGER.warning(
+                "Failed to get value from accessor %r: %s",
+                value_reference,
+                err,
+            )
+            return None
+        return value if isinstance(value, (int, float)) else None
+
+    def has_value(
+        self,
+        value_reference: Callable[[Wpm3iStiebelEltronAPI], float | int | None],
+    ) -> bool:
+        """Check if a callable accessor has a value."""
+        return self.get_value(value_reference) is not None
+
+    async def write_component_value(
+        self,
+        component: str,
+        field: str,
+        value: int | float,
+    ) -> None:
+        """Write a value to a component field."""
+        if self._api is not None:
+            component_obj = getattr(self._api, component, None)
+            if component_obj is not None and hasattr(component_obj, field):
+                await component_obj.write(field, value)
+
+    async def async_reset_heatpump(self) -> None:
+        """Reset the heat pump."""
+        _LOGGER.debug("Reset the heat pump")
+        if self._api is not None:
+            await self._api.system_parameters.write(
+                "reset",
+                3,
+            )
+
+    def get_raw_data(self) -> dict:
+        """Return the raw data from the heat pump."""
+        result: dict = {}
+        for component in vars(self._api).values():
+            component_result = dict(field_rows(component))
+            result = {**result, **component_result}
+        return result

--- a/custom_components/stiebel_eltron_isg/wpm3i_coordinator.py
+++ b/custom_components/stiebel_eltron_isg/wpm3i_coordinator.py
@@ -57,8 +57,7 @@ class StiebelEltronModbusWPM3iDataCoordinator(StiebelEltronDataCoordinator):
     ) -> float | int | None:
         """Return a value from a callable accessor."""
         try:
-            if self._api is not None:
-                value = value_reference(self._api)
+            value = value_reference(self._api)
         except StiebelEltronModbusError as err:
             _LOGGER.warning(
                 "Failed to get value from accessor %r: %s",
@@ -82,19 +81,17 @@ class StiebelEltronModbusWPM3iDataCoordinator(StiebelEltronDataCoordinator):
         value: int | float,
     ) -> None:
         """Write a value to a component field."""
-        if self._api is not None:
-            component_obj = getattr(self._api, component, None)
-            if component_obj is not None and hasattr(component_obj, field):
-                await component_obj.write(field, value)
+        component_obj = getattr(self._api, component, None)
+        if component_obj is not None and hasattr(component_obj, field):
+            await component_obj.write(field, value)
 
     async def async_reset_heatpump(self) -> None:
         """Reset the heat pump."""
         _LOGGER.debug("Reset the heat pump")
-        if self._api is not None:
-            await self._api.system_parameters.write(
-                "reset",
-                3,
-            )
+        await self._api.system_parameters.write(
+            "reset",
+            3,
+        )
 
     def get_raw_data(self) -> dict:
         """Return the raw data from the heat pump."""

--- a/custom_components/stiebel_eltron_isg/wpm_coordinator.py
+++ b/custom_components/stiebel_eltron_isg/wpm_coordinator.py
@@ -57,8 +57,7 @@ class StiebelEltronModbusWPMDataCoordinator(StiebelEltronDataCoordinator):
     ) -> float | int | None:
         """Return a value from a callable accessor."""
         try:
-            if self._api is not None:
-                value = value_reference(self._api)
+            value = value_reference(self._api)
         except StiebelEltronModbusError as err:
             _LOGGER.warning(
                 "Failed to get value from accessor %r: %s",
@@ -82,19 +81,17 @@ class StiebelEltronModbusWPMDataCoordinator(StiebelEltronDataCoordinator):
         value: int | float,
     ) -> None:
         """Write a value to a component field."""
-        if self._api is not None:
-            component_obj = getattr(self._api, component, None)
-            if component_obj is not None and hasattr(component_obj, field):
-                await component_obj.write(field, value)
+        component_obj = getattr(self._api, component, None)
+        if component_obj is not None and hasattr(component_obj, field):
+            await component_obj.write(field, value)
 
     async def async_reset_heatpump(self) -> None:
         """Reset the heat pump."""
         _LOGGER.debug("Reset the heat pump")
-        if self._api is not None:
-            await self._api.system_parameters.write(
-                "reset",
-                3,
-            )
+        await self._api.system_parameters.write(
+            "reset",
+            3,
+        )
 
     def get_raw_data(self) -> dict:
         """Return the raw data from the heat pump."""

--- a/custom_components/stiebel_eltron_isg/wpm_coordinator.py
+++ b/custom_components/stiebel_eltron_isg/wpm_coordinator.py
@@ -42,10 +42,6 @@ class StiebelEltronModbusWPMDataCoordinator(StiebelEltronDataCoordinator):
         """Time to update."""
         try:
             await self._api.async_update()
-            self._model_id = (
-                self._api.energy_system_information.controller_identification
-            ) or 0
-
         except ModbusError as exception:
             raise UpdateFailed(exception) from exception
         else:


### PR DESCRIPTION
## Summary by Sourcery

Add dedicated support for the WPM 3i controller model with its own Modbus API, data coordinator, and tailored entity sets, while refactoring model handling across the integration.

New Features:
- Expose WPM 3i-specific system value sensors, binary sensors, climate entities, and number entities based on a new Modbus API definition.
- Introduce a separate WPM 3i data coordinator that uses the dedicated WPM 3i Modbus API for updates and writes.

Enhancements:
- Refine controller model handling by using the ControllerModel enum throughout and adding a model_name helper for clearer identification.
- Adjust existing WPM/LWZ coordinators and entities to rely on the pre-resolved controller model instead of reading model IDs at runtime and simplify access to the underlying API.
- Restrict certain switches and number entities to only the appropriate controller models and correct DHW temperature parameter mappings.
- Set the humidity device class on humidity sensors for improved typing in Home Assistant.