### PR TITLE
Add LWZ compressor frequency sensor

### DIFF
--- a/custom_components/stiebel_eltron_isg/const.py
+++ b/custom_components/stiebel_eltron_isg/const.py
@@ -126,6 +126,7 @@ CONSUMED_WATER_HEATING = "consumed_water_heating"
 CURRENT_POWER_CONSUMPTION = "current_power_consumption"
 
 COMPRESSOR_STARTS = "compressor_starts"
+COMPRESSOR_SPEED = "compressor_speed"
 COMPRESSOR_HEATING = "compressor_heating"
 COMPRESSOR_HEATING_WATER = "compressor_heating_water"
 COOLING_RUNTIME = "cooling_runtime"

--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -46,6 +46,7 @@ from .const import (
     ACTUAL_TEMPERATURE_WATER,
     COMPRESSOR_HEATING,
     COMPRESSOR_HEATING_WATER,
+    COMPRESSOR_SPEED,
     COMPRESSOR_STARTS,
     CONSUMED_HEATING,
     CONSUMED_HEATING_TODAY,
@@ -1020,6 +1021,15 @@ LWZ_COMPRESSOR_SENSOR_TYPES = [
         translation_key=COMPRESSOR_STARTS,
         icon="mdi:restart",
         modbus_register=lambda api: api.system_values.compressor_starts,
+    ),
+    StiebelEltronSensorEntityDescription(
+        key=COMPRESSOR_SPEED,
+        translation_key=COMPRESSOR_SPEED,
+        icon="mdi:sine-wave",
+        native_unit_of_measurement=UnitOfFrequency.HERTZ,
+        device_class=SensorDeviceClass.FREQUENCY,
+        state_class=SensorStateClass.MEASUREMENT,
+        modbus_register=lambda api: api.system_values.compressor_speed,
     ),
     StiebelEltronSensorEntityDescription(
         key=COMPRESSOR_HEATING,

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -308,6 +308,9 @@
             "compressor_starts": {
                 "name": "Compressor Starts"
             },
+            "compressor_speed": {
+                "name": "Compressor Frequency"
+            },
             "compressor_heating": {
                 "name": "Compressor Heating"
             },

--- a/custom_components/stiebel_eltron_isg/translations/cz.json
+++ b/custom_components/stiebel_eltron_isg/translations/cz.json
@@ -308,6 +308,9 @@
             "compressor_starts": {
                 "name": "Starty kompresoru"
             },
+            "compressor_speed": {
+                "name": "Frekvence kompresoru"
+            },
             "compressor_heating": {
                 "name": "Kompresor topení"
             },

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -308,6 +308,9 @@
             "compressor_starts": {
                 "name": "Verdichterstarts"
             },
+            "compressor_speed": {
+                "name": "Verdichterfrequenz"
+            },
             "compressor_heating": {
                 "name": "Verdichter Heizung"
             },

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -297,6 +297,9 @@
             "compressor_starts": {
                 "name": "Compressor Starts"
             },
+            "compressor_speed": {
+                "name": "Compressor Frequency"
+            },
             "compressor_heating": {
                 "name": "Compressor Heating"
             },

--- a/custom_components/stiebel_eltron_isg/translations/fr.json
+++ b/custom_components/stiebel_eltron_isg/translations/fr.json
@@ -308,6 +308,9 @@
             "compressor_starts": {
                 "name": "Démarrages compresseur"
             },
+            "compressor_speed": {
+                "name": "Fréquence compresseur"
+            },
             "compressor_heating": {
                 "name": "Compresseur chauffage"
             },

--- a/custom_components/stiebel_eltron_isg/translations/it.json
+++ b/custom_components/stiebel_eltron_isg/translations/it.json
@@ -308,6 +308,9 @@
             "compressor_starts": {
                 "name": "Avviamenti compressore"
             },
+            "compressor_speed": {
+                "name": "Frequenza compressore"
+            },
             "compressor_heating": {
                 "name": "Compressore riscaldamento"
             },

--- a/custom_components/stiebel_eltron_isg/translations/pt.json
+++ b/custom_components/stiebel_eltron_isg/translations/pt.json
@@ -308,6 +308,9 @@
             "compressor_starts": {
                 "name": "Arranques do compressor"
             },
+            "compressor_speed": {
+                "name": "Frequência do compressor"
+            },
             "compressor_heating": {
                 "name": "Compressor aquecimento"
             },

--- a/custom_components/stiebel_eltron_isg/translations/sk.json
+++ b/custom_components/stiebel_eltron_isg/translations/sk.json
@@ -308,6 +308,9 @@
             "compressor_starts": {
                 "name": "Štarty kompresora"
             },
+            "compressor_speed": {
+                "name": "Frekvencia kompresora"
+            },
             "compressor_heating": {
                 "name": "Kompresor vykurovanie"
             },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,12 +2,17 @@
 
 from types import SimpleNamespace
 
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import UnitOfFrequency
+
 from custom_components.stiebel_eltron_isg.const import (
     COMPRESSOR_HEATING,
     COMPRESSOR_HEATING_WATER,
+    COMPRESSOR_SPEED,
     COOLING_RUNTIME,
 )
 from custom_components.stiebel_eltron_isg.sensor import (
+    LWZ_SENSOR_TYPES,
     WPM_3I_SENSOR_TYPES,
     WPM_SENSOR_TYPES,
 )
@@ -15,6 +20,10 @@ from custom_components.stiebel_eltron_isg.sensor import (
 
 def _wpm(key: str):
     return next(d for d in WPM_SENSOR_TYPES if d.key == key)
+
+
+def _lwz(key: str):
+    return next(d for d in LWZ_SENSOR_TYPES if d.key == key)
 
 
 def test_wpm_exposes_compressor_runtime_hours() -> None:
@@ -40,3 +49,13 @@ def test_wpm_3i_exposes_compressor_runtime_hours() -> None:
     """WPM_3i shares the vd_heating/vd_dhw/vd_cooling registers (3516-3518)."""
     keys = {d.key for d in WPM_3I_SENSOR_TYPES}
     assert {COMPRESSOR_HEATING, COMPRESSOR_HEATING_WATER, COOLING_RUNTIME} <= keys
+
+
+def test_lwz_exposes_compressor_frequency() -> None:
+    """LWZ compressor frequency reads system_values.compressor_speed (Hz)."""
+    api = SimpleNamespace(system_values=SimpleNamespace(compressor_speed=31.0))
+
+    speed = _lwz(COMPRESSOR_SPEED)
+    assert speed.modbus_register(api) == 31.0
+    assert speed.native_unit_of_measurement == UnitOfFrequency.HERTZ
+    assert speed.device_class == SensorDeviceClass.FREQUENCY


### PR DESCRIPTION
Exposes the LWZ/THZ compressor frequency (system-values register 31, `compressor_speed`) as a sensor with the `frequency` device class in Hz.

`pystiebeleltron` already provides this as a `0.1`-scaled `Hz` gauge, so the value is read directly via `api.system_values.compressor_speed` with no custom scaling.

Reimplements the idea from #536 (@rokda106) against the current library-backed sensor architecture (the old `IsgRegisters` / `scale_factor` pattern no longer exists). Supersedes #536.

- Added `compressor_speed` sensor to `LWZ_COMPRESSOR_SENSOR_TYPES`
- Translations in `strings.json`, `en`, `de` (+ `sk`, `it`, `cz`, `pt`, `fr`)
- Unit test in `tests/test_sensor.py`

## Summary by Sourcery

Expose LWZ compressor compressor frequency as a dedicated sensor backed by the library’s system_values API.

New Features:
- Add an LWZ compressor frequency sensor using the frequency device class with Hz units.

Enhancements:
- Add translation entries for the compressor frequency sensor key across supported locales.

Tests:
- Add a unit test verifying the LWZ compressor frequency sensor reads compressor_speed and reports correct unit and device class.