### PR TITLE
Add WPM power-consumption statistics sensors

### DIFF
--- a/custom_components/stiebel_eltron_isg/const.py
+++ b/custom_components/stiebel_eltron_isg/const.py
@@ -123,6 +123,19 @@ CONSUMED_WATER_HEATING_TOTAL = "consumed_water_heating_total"
 PREVIOUS_CONSUMED_WATER_HEATING_TOTAL = "previous_consumed_water_heating_total"
 CONSUMED_WATER_HEATING = "consumed_water_heating"
 
+# WPM power-consumption breakdown (Servicewelt "POWER CONSUMPTION" screen,
+# Modbus registers 3707-3723): rolling sums over the last 24 h, the last
+# 12 months and the previous 12 months.
+CONSUMED_HEATING_LAST_24H = "consumed_heating_last_24h"
+CONSUMED_HEATING_12M = "consumed_heating_12m"
+CONSUMED_HEATING_PREV_12M = "consumed_heating_prev_12m"
+CONSUMED_COOLING_LAST_24H = "consumed_cooling_last_24h"
+CONSUMED_COOLING_12M = "consumed_cooling_12m"
+CONSUMED_COOLING_PREV_12M = "consumed_cooling_prev_12m"
+CONSUMED_WATER_HEATING_LAST_24H = "consumed_water_heating_last_24h"
+CONSUMED_WATER_HEATING_12M = "consumed_water_heating_12m"
+CONSUMED_WATER_HEATING_PREV_12M = "consumed_water_heating_prev_12m"
+
 CURRENT_POWER_CONSUMPTION = "current_power_consumption"
 
 COMPRESSOR_STARTS = "compressor_starts"

--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -47,10 +47,19 @@ from .const import (
     COMPRESSOR_HEATING,
     COMPRESSOR_HEATING_WATER,
     COMPRESSOR_STARTS,
+    CONSUMED_COOLING_12M,
+    CONSUMED_COOLING_LAST_24H,
+    CONSUMED_COOLING_PREV_12M,
     CONSUMED_HEATING,
+    CONSUMED_HEATING_12M,
+    CONSUMED_HEATING_LAST_24H,
+    CONSUMED_HEATING_PREV_12M,
     CONSUMED_HEATING_TODAY,
     CONSUMED_HEATING_TOTAL,
     CONSUMED_WATER_HEATING,
+    CONSUMED_WATER_HEATING_12M,
+    CONSUMED_WATER_HEATING_LAST_24H,
+    CONSUMED_WATER_HEATING_PREV_12M,
     CONSUMED_WATER_HEATING_TODAY,
     CONSUMED_WATER_HEATING_TOTAL,
     COOLING_RUNTIME,
@@ -181,6 +190,27 @@ def create_energy_entity_description(
         state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.ENERGY,
         entity_registry_visible_default=visible_default,
+        modbus_register=modbus_register,
+    )
+
+
+def create_power_consumption_entity_description(
+    name: str,
+    key: str,
+    modbus_register: StiebelEltronModbusRegister,
+) -> StiebelEltronSensorEntityDescription:
+    """Create a power-consumption window sensor (rolling sum, resets over time).
+
+    These are the Servicewelt "POWER CONSUMPTION" statistics. Because the
+    windows reset, they use ``TOTAL`` rather than ``TOTAL_INCREASING``.
+    """
+    return StiebelEltronSensorEntityDescription(
+        key=key,
+        translation_key=key,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        icon="mdi:meter-electric",
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.ENERGY,
         modbus_register=modbus_register,
     )
 
@@ -1138,6 +1168,57 @@ WPM_COMPRESSOR_SENSOR_TYPES = [
     ),
 ]
 
+# Servicewelt "POWER CONSUMPTION" screen (Modbus registers 3707-3723). The
+# pystiebeleltron library already decodes each register pair into a kWh value,
+# so these read the plain energy_data fields.
+WPM_POWER_CONSUMPTION_SENSOR_TYPES = [
+    create_power_consumption_entity_description(
+        "Consumed Heating Last 24h",
+        CONSUMED_HEATING_LAST_24H,
+        lambda api: api.energy_data.heating_24h,
+    ),
+    create_power_consumption_entity_description(
+        "Consumed Heating Last 12 Months",
+        CONSUMED_HEATING_12M,
+        lambda api: api.energy_data.heating_12m,
+    ),
+    create_power_consumption_entity_description(
+        "Consumed Heating Previous 12 Months",
+        CONSUMED_HEATING_PREV_12M,
+        lambda api: api.energy_data.heating_13_24,
+    ),
+    create_power_consumption_entity_description(
+        "Consumed Cooling Last 24h",
+        CONSUMED_COOLING_LAST_24H,
+        lambda api: api.energy_data.cooling_24h,
+    ),
+    create_power_consumption_entity_description(
+        "Consumed Cooling Last 12 Months",
+        CONSUMED_COOLING_12M,
+        lambda api: api.energy_data.cooling_12m,
+    ),
+    create_power_consumption_entity_description(
+        "Consumed Cooling Previous 12 Months",
+        CONSUMED_COOLING_PREV_12M,
+        lambda api: api.energy_data.cooling_13_24,
+    ),
+    create_power_consumption_entity_description(
+        "Consumed Water Heating Last 24h",
+        CONSUMED_WATER_HEATING_LAST_24H,
+        lambda api: api.energy_data.dhw_24h,
+    ),
+    create_power_consumption_entity_description(
+        "Consumed Water Heating Last 12 Months",
+        CONSUMED_WATER_HEATING_12M,
+        lambda api: api.energy_data.dhw_12m,
+    ),
+    create_power_consumption_entity_description(
+        "Consumed Water Heating Previous 12 Months",
+        CONSUMED_WATER_HEATING_PREV_12M,
+        lambda api: api.energy_data.dhw_13_24,
+    ),
+]
+
 
 WPM_3I_SENSOR_TYPES = (
     WPM_3I_SYSTEM_VALUES_SENSOR_TYPES
@@ -1151,6 +1232,7 @@ WPM_SENSOR_TYPES = (
     + ENERGYMANAGEMENT_SENSOR_TYPES
     + ENERGY_SENSOR_TYPES
     + WPM_COMPRESSOR_SENSOR_TYPES
+    + WPM_POWER_CONSUMPTION_SENSOR_TYPES
 )
 
 LWZ_SENSOR_TYPES = (

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -260,6 +260,33 @@
             "consumed_water_heating": {
                 "name": "Consumed Water Heating"
             },
+            "consumed_heating_last_24h": {
+                "name": "Consumed Heating Last 24h"
+            },
+            "consumed_heating_12m": {
+                "name": "Consumed Heating Last 12 Months"
+            },
+            "consumed_heating_prev_12m": {
+                "name": "Consumed Heating Previous 12 Months"
+            },
+            "consumed_cooling_last_24h": {
+                "name": "Consumed Cooling Last 24h"
+            },
+            "consumed_cooling_12m": {
+                "name": "Consumed Cooling Last 12 Months"
+            },
+            "consumed_cooling_prev_12m": {
+                "name": "Consumed Cooling Previous 12 Months"
+            },
+            "consumed_water_heating_last_24h": {
+                "name": "Consumed Water Heating Last 24h"
+            },
+            "consumed_water_heating_12m": {
+                "name": "Consumed Water Heating Last 12 Months"
+            },
+            "consumed_water_heating_prev_12m": {
+                "name": "Consumed Water Heating Previous 12 Months"
+            },
             "produced_electrical_booster_heating_total": {
                 "name": "Produced Electrical Booster Heating Total"
             },

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -260,6 +260,33 @@
             "consumed_water_heating": {
                 "name": "Verbrauchte Warmwasserenergie"
             },
+            "consumed_heating_last_24h": {
+                "name": "Verbrauchte Heizenergie letzte 24 h"
+            },
+            "consumed_heating_12m": {
+                "name": "Verbrauchte Heizenergie letzte 12 Monate"
+            },
+            "consumed_heating_prev_12m": {
+                "name": "Verbrauchte Heizenergie vorherige 12 Monate"
+            },
+            "consumed_cooling_last_24h": {
+                "name": "Verbrauchte Kühlenergie letzte 24 h"
+            },
+            "consumed_cooling_12m": {
+                "name": "Verbrauchte Kühlenergie letzte 12 Monate"
+            },
+            "consumed_cooling_prev_12m": {
+                "name": "Verbrauchte Kühlenergie vorherige 12 Monate"
+            },
+            "consumed_water_heating_last_24h": {
+                "name": "Verbrauchte Warmwasserenergie letzte 24 h"
+            },
+            "consumed_water_heating_12m": {
+                "name": "Verbrauchte Warmwasserenergie letzte 12 Monate"
+            },
+            "consumed_water_heating_prev_12m": {
+                "name": "Verbrauchte Warmwasserenergie vorherige 12 Monate"
+            },
             "produced_electrical_booster_heating_total": {
                 "name": "Erzeugte Elektroheizung Heizung gesamt"
             },

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -249,6 +249,33 @@
             "consumed_water_heating": {
                 "name": "Consumed Water Heating"
             },
+            "consumed_heating_last_24h": {
+                "name": "Consumed Heating Last 24h"
+            },
+            "consumed_heating_12m": {
+                "name": "Consumed Heating Last 12 Months"
+            },
+            "consumed_heating_prev_12m": {
+                "name": "Consumed Heating Previous 12 Months"
+            },
+            "consumed_cooling_last_24h": {
+                "name": "Consumed Cooling Last 24h"
+            },
+            "consumed_cooling_12m": {
+                "name": "Consumed Cooling Last 12 Months"
+            },
+            "consumed_cooling_prev_12m": {
+                "name": "Consumed Cooling Previous 12 Months"
+            },
+            "consumed_water_heating_last_24h": {
+                "name": "Consumed Water Heating Last 24h"
+            },
+            "consumed_water_heating_12m": {
+                "name": "Consumed Water Heating Last 12 Months"
+            },
+            "consumed_water_heating_prev_12m": {
+                "name": "Consumed Water Heating Previous 12 Months"
+            },
             "produced_electrical_booster_heating_total": {
                 "name": "Produced Electrical Booster Heating Total"
             },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,9 +2,21 @@
 
 from types import SimpleNamespace
 
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfEnergy
+
 from custom_components.stiebel_eltron_isg.const import (
     COMPRESSOR_HEATING,
     COMPRESSOR_HEATING_WATER,
+    CONSUMED_COOLING_12M,
+    CONSUMED_COOLING_LAST_24H,
+    CONSUMED_COOLING_PREV_12M,
+    CONSUMED_HEATING_12M,
+    CONSUMED_HEATING_LAST_24H,
+    CONSUMED_HEATING_PREV_12M,
+    CONSUMED_WATER_HEATING_12M,
+    CONSUMED_WATER_HEATING_LAST_24H,
+    CONSUMED_WATER_HEATING_PREV_12M,
     COOLING_RUNTIME,
 )
 from custom_components.stiebel_eltron_isg.sensor import (
@@ -40,3 +52,39 @@ def test_wpm_3i_exposes_compressor_runtime_hours() -> None:
     """WPM_3i shares the vd_heating/vd_dhw/vd_cooling registers (3516-3518)."""
     keys = {d.key for d in WPM_3I_SENSOR_TYPES}
     assert {COMPRESSOR_HEATING, COMPRESSOR_HEATING_WATER, COOLING_RUNTIME} <= keys
+
+
+def test_wpm_exposes_power_consumption_statistics() -> None:
+    """WPM power-consumption windows read the 3707-3723 energy_data fields (kWh)."""
+    api = SimpleNamespace(
+        energy_data=SimpleNamespace(
+            heating_24h=12,
+            heating_12m=3456,
+            heating_13_24=3210,
+            cooling_24h=1,
+            cooling_12m=210,
+            cooling_13_24=198,
+            dhw_24h=5,
+            dhw_12m=1500,
+            dhw_13_24=1450,
+        )
+    )
+    expected = {
+        CONSUMED_HEATING_LAST_24H: ("heating_24h", 12),
+        CONSUMED_HEATING_12M: ("heating_12m", 3456),
+        CONSUMED_HEATING_PREV_12M: ("heating_13_24", 3210),
+        CONSUMED_COOLING_LAST_24H: ("cooling_24h", 1),
+        CONSUMED_COOLING_12M: ("cooling_12m", 210),
+        CONSUMED_COOLING_PREV_12M: ("cooling_13_24", 198),
+        CONSUMED_WATER_HEATING_LAST_24H: ("dhw_24h", 5),
+        CONSUMED_WATER_HEATING_12M: ("dhw_12m", 1500),
+        CONSUMED_WATER_HEATING_PREV_12M: ("dhw_13_24", 1450),
+    }
+
+    for key, (_field, value) in expected.items():
+        desc = _wpm(key)
+        assert desc.modbus_register(api) == value
+        assert desc.native_unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR
+        assert desc.device_class == SensorDeviceClass.ENERGY
+        # Rolling windows reset, so they must not be TOTAL_INCREASING.
+        assert desc.state_class == SensorStateClass.TOTAL


### PR DESCRIPTION
Exposes the Servicewelt **POWER CONSUMPTION** screen (Modbus registers 3707-3723) as nine WPM sensors: consumed **heating / cooling / water-heating** over the **last 24 h**, the **last 12 months** and the **previous 12 months**.

`pystiebeleltron` 0.6.0 already decodes each register pair into a kWh value (`energy_data.heating_24h/12m/13_24`, `cooling_*`, `dhw_*`), so no custom register decoding is needed.

Notes:
- `device_class=ENERGY`, unit kWh, `state_class=TOTAL` — the windows reset, so `TOTAL_INCREASING` would be wrong. (`MEASUREMENT` is not valid for `ENERGY`.)
- WPM only — `Wpm3iEnergyData` does not expose these registers.
- No overlap with the existing lifetime `consumed_*_total` sensors.

Reimplements the idea from #544 (@bartveenstra) against the current library-backed sensor architecture; the library now handles the whole/fraction decoding that the original PR did manually. Supersedes #544.

- Added `WPM_POWER_CONSUMPTION_SENSOR_TYPES` + `create_power_consumption_entity_description` helper
- Translations in `strings.json`, `en`, `de`
- Unit test in `tests/test_sensor.py`

## Summary by Sourcery

Expose WPM power-consumption statistics as dedicated energy sensors for heating, cooling, and water heating over rolling time windows.

New Features:
- Add nine WPM sensors for heating, cooling, and water-heating consumption over the last 24 hours, last 12 months, and previous 12 months.

Enhancements:
- Introduce a shared helper for defining power-consumption window sensors with appropriate energy device and state classes.
- Integrate the new power-consumption sensors into the existing WPM_3I sensor set.

Documentation:
- Add localized strings for the new WPM power-consumption sensors in the base strings file and English/German translations.

Tests:
- Add unit test coverage to verify WPM power-consumption sensors read the correct energy_data fields and use the expected units, device class, and state class.