### PR TITLE
Guard every entity description against its model's API

### DIFF
--- a/custom_components/stiebel_eltron_isg/switch.py
+++ b/custom_components/stiebel_eltron_isg/switch.py
@@ -73,6 +73,18 @@ SWITCH_TYPES = [
     ),
 ]
 
+# Only for controllers that expose a domestic hot water circulation pump.
+CIRCULATION_PUMP_SWITCH_TYPES = [
+    StiebelEltronSwitchEntityDescription(
+        key=CIRCULATION_PUMP,
+        translation_key=CIRCULATION_PUMP,
+        device_class=SwitchDeviceClass.SWITCH,
+        modbus_register=lambda api: api.system_state.dhw_circulation_pump,
+        write_component="system_state",
+        write_field="dhw_circulation_pump",
+    ),
+]
+
 
 async def async_setup_entry(
     _hass: HomeAssistant,
@@ -93,19 +105,13 @@ async def async_setup_entry(
 
     if coordinator.model in (ControllerModel.LWZ_R290, ControllerModel.WPMsystem):
         # Add the circulation pump switch for WPM systems
-        entities.append(
+        entities.extend(
             StiebelEltronISGSwitch(
                 coordinator,
                 entry,
-                StiebelEltronSwitchEntityDescription(
-                    key=CIRCULATION_PUMP,
-                    translation_key=CIRCULATION_PUMP,
-                    device_class=SwitchDeviceClass.SWITCH,
-                    modbus_register=lambda api: api.system_state.dhw_circulation_pump,
-                    write_component="system_state",
-                    write_field="dhw_circulation_pump",
-                ),
+                description,
             )
+            for description in CIRCULATION_PUMP_SWITCH_TYPES
         )
 
     async_add_devices(entities)

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -1,0 +1,203 @@
+"""Guards that every entity description resolves against its model's API.
+
+All platforms declare their entities as descriptions holding lambda accessors
+(``lambda api: api.<component>.<field>``) plus the ``write_field`` name that
+``write_component_value`` writes to. A description used for a model whose API
+does not have that field breaks only at runtime: the accessor raises
+``AttributeError`` (the coordinator only catches ``StiebelEltronModbusError``)
+and the write silently no-ops (``write_component_value`` guards with
+``hasattr``). The tests below therefore resolve every accessor and every write
+field of every model specific description list against the API class the
+coordinator really builds for that model, and check that no description list
+escapes that sweep.
+"""
+
+from functools import cache
+from types import ModuleType
+from typing import Any
+
+from homeassistant.helpers.entity import EntityDescription
+from modbus_connection.mock import MockModbusConnection
+from pystiebeleltron.lwz import LwzStiebelEltronAPI
+from pystiebeleltron.wpm import WpmStiebelEltronAPI
+from pystiebeleltron.wpm3i import Wpm3iStiebelEltronAPI
+import pytest
+
+from custom_components.stiebel_eltron_isg import (
+    binary_sensor,
+    climate,
+    number,
+    select,
+    sensor,
+    switch,
+)
+from custom_components.stiebel_eltron_isg.const import UNIT_ID
+
+WPM = "wpm"
+WPM_3I = "wpm_3i"
+LWZ = "lwz"
+
+_API_CLASSES = {
+    WPM: WpmStiebelEltronAPI,
+    WPM_3I: Wpm3iStiebelEltronAPI,
+    LWZ: LwzStiebelEltronAPI,
+}
+
+# button is left out on purpose: its descriptions carry a coordinator level
+# press_action rather than an api accessor, and the same list serves every model.
+_PLATFORM_MODULES = (binary_sensor, climate, number, select, sensor, switch)
+
+# Description attributes holding an accessor lambda, or a list of them.
+_ACCESSOR_ATTRIBUTES = (
+    "modbus_register",
+    "humidity_modbus_register",
+    "actual_temperature_register",
+    "eco_target_temp_register",
+    "comfort_target_temp_register",
+)
+
+# Description attributes holding the name of a writable component field.
+_WRITE_FIELD_ATTRIBUTES = (
+    "write_field",
+    "eco_target_temp_write_field",
+    "comfort_target_temp_write_field",
+)
+
+# Every description list a platform hands to a model, with that model. Lists
+# used by more than one model appear once per model. Lists that only exist to
+# be spliced into one of these are covered through their parent;
+# ``test_every_description_is_covered`` fails if one is missed entirely.
+_DESCRIPTION_LISTS: list[tuple[str, str, list[Any]]] = [
+    ("NUMBER_TYPES_WPM", WPM, number.NUMBER_TYPES_WPM),
+    ("NUMBER_TYPES_WPM_3I", WPM_3I, number.NUMBER_TYPES_WPM_3I),
+    ("NUMBER_TYPES_LWZ", LWZ, number.NUMBER_TYPES_LWZ),
+    ("WPM_SENSOR_TYPES", WPM, sensor.WPM_SENSOR_TYPES),
+    ("WPM_3I_SENSOR_TYPES", WPM_3I, sensor.WPM_3I_SENSOR_TYPES),
+    ("LWZ_SENSOR_TYPES", LWZ, sensor.LWZ_SENSOR_TYPES),
+    ("ENERGY_DAILY_SENSOR_TYPES", WPM, sensor.ENERGY_DAILY_SENSOR_TYPES),
+    ("ENERGY_DAILY_SENSOR_TYPES", WPM_3I, sensor.ENERGY_DAILY_SENSOR_TYPES),
+    ("LWZ_ENERGY_DAILY_SENSOR_TYPES", LWZ, sensor.LWZ_ENERGY_DAILY_SENSOR_TYPES),
+    ("WPM_BINARY_SENSOR_TYPES", WPM, binary_sensor.WPM_BINARY_SENSOR_TYPES),
+    ("WPM_3I_BINARY_SENSOR_TYPES", WPM_3I, binary_sensor.WPM_3I_BINARY_SENSOR_TYPES),
+    ("LWZ_BINARY_SENSOR_TYPES", LWZ, binary_sensor.LWZ_BINARY_SENSOR_TYPES),
+    ("SWITCH_TYPES", WPM, switch.SWITCH_TYPES),
+    ("SWITCH_TYPES", WPM_3I, switch.SWITCH_TYPES),
+    ("SWITCH_TYPES", LWZ, switch.SWITCH_TYPES),
+    # WPMsystem and LWZ_R290, both of which are served by the WPM api.
+    ("CIRCULATION_PUMP_SWITCH_TYPES", WPM, switch.CIRCULATION_PUMP_SWITCH_TYPES),
+    ("WPM_SELECT_TYPES", WPM, select.WPM_SELECT_TYPES),
+    ("WPM_SELECT_TYPES", WPM_3I, select.WPM_SELECT_TYPES),
+    ("LWZ_SELECT_TYPES", LWZ, select.LWZ_SELECT_TYPES),
+    ("WPM_CLIMATE_TYPES", WPM, climate.WPM_CLIMATE_TYPES),
+    ("WPM_3I_CLIMATE_TYPES", WPM_3I, climate.WPM_3I_CLIMATE_TYPES),
+    ("LWZ_CLIMATE_TYPES", LWZ, climate.LWZ_CLIMATE_TYPES),
+]
+
+
+@cache
+def _api(model: str) -> Any:
+    """Return the API object a coordinator builds for ``model``."""
+    return _API_CLASSES[model](MockModbusConnection().for_unit(UNIT_ID))
+
+
+def _module_description_lists(module: ModuleType) -> list[tuple[str, list[Any]]]:
+    """Return every module level list of entity descriptions of ``module``."""
+    lists = []
+    for name, value in vars(module).items():
+        if not isinstance(value, (list, tuple)) or not value:
+            continue
+        if all(isinstance(item, EntityDescription) for item in value):
+            lists.append((name, list(value)))
+    return lists
+
+
+def _accessor_cases() -> list[Any]:
+    """Return a param per accessor of every description, carrying its test id."""
+    cases = []
+    for list_name, model, descriptions in _DESCRIPTION_LISTS:
+        for description in descriptions:
+            for attribute in _ACCESSOR_ATTRIBUTES:
+                value = getattr(description, attribute, None)
+                if value is None:
+                    continue
+                # Climate descriptions hold a list of accessors per attribute.
+                accessors = value if isinstance(value, list) else [value]
+                name = f"{list_name}-{model}-{description.key}-{attribute}"
+                cases.extend(
+                    pytest.param(
+                        model,
+                        accessor,
+                        id=f"{name}[{index}]" if len(accessors) > 1 else name,
+                    )
+                    for index, accessor in enumerate(accessors)
+                )
+    return cases
+
+
+def _write_field_cases() -> list[Any]:
+    """Return a param per write field of every description, with its test id."""
+    cases = []
+    for list_name, model, descriptions in _DESCRIPTION_LISTS:
+        for description in descriptions:
+            component = getattr(description, "write_component", None)
+            if component is None:
+                continue
+            cases.extend(
+                pytest.param(
+                    model,
+                    component,
+                    getattr(description, attribute),
+                    id=f"{list_name}-{model}-{description.key}-{attribute}",
+                )
+                for attribute in _WRITE_FIELD_ATTRIBUTES
+                if getattr(description, attribute, None) is not None
+            )
+    return cases
+
+
+@pytest.mark.parametrize(("model", "accessor"), _accessor_cases())
+def test_description_accessor_resolves(model: str, accessor: Any) -> None:
+    """Every accessor must resolve against the API of the model using it."""
+    accessor(_api(model))
+
+
+@pytest.mark.parametrize(("model", "component", "field"), _write_field_cases())
+def test_description_write_field_resolves(
+    model: str, component: str, field: str
+) -> None:
+    """Every write field must exist on the component of the model using it."""
+    component_object = getattr(_api(model), component, None)
+
+    assert component_object is not None, f"{model} api has no component {component}"
+    assert hasattr(component_object, field), (
+        f"{type(component_object).__name__} has no field {field}"
+    )
+
+
+@pytest.mark.parametrize(
+    "module", _PLATFORM_MODULES, ids=lambda module: module.__name__.rsplit(".", 1)[-1]
+)
+def test_every_description_is_covered(module: ModuleType) -> None:
+    """No description list may escape the sweep above.
+
+    Keeps ``_DESCRIPTION_LISTS`` from going stale: a new list, or a list that
+    stops being spliced into a covered one, has to be registered with the model
+    that uses it before it can be shipped.
+    """
+    covered = {
+        id(description)
+        for _, _, descriptions in _DESCRIPTION_LISTS
+        for description in descriptions
+    }
+
+    missing = {
+        f"{name}: {description.key}"
+        for name, descriptions in _module_description_lists(module)
+        for description in descriptions
+        if id(description) not in covered
+    }
+
+    assert not missing, (
+        f"descriptions of {module.__name__} not covered by _DESCRIPTION_LISTS: "
+        f"{sorted(missing)}"
+    )


### PR DESCRIPTION
Rebased onto current main and reduced to the part that does not depend on the
naming, as discussed. The DHW accessor fix is gone: pystiebeleltron 0.6.1 renames
registers 1509 and 1510 to `comfort_temperature_dhw` / `eco_temperature_dhw` on
the WPM api as well, so the shared list in `number.py` is correct as it stands on
main and needs no per-model split. Verified against the 0.6.1 that main pins.

That also means #582 is already fixed on main by the bump, not by this PR, so
this no longer carries a closing reference to it. It can be closed independently,
and `test_description_accessor_resolves` now covers the two entities it was about.

What is left is the guard that would have caught the rename before release.

## The problem it guards against

Every platform declares its entities as descriptions holding lambda accessors
(`lambda api: api.<component>.<field>`) plus the `write_field` name that
`write_component_value` writes to. A description used for a model whose api does
not have that field breaks only at runtime, and quietly:

- the accessor raises `AttributeError`, which the coordinator does not catch, as
  it only catches `StiebelEltronModbusError`, so the exception escapes
  `native_value` and `available`,
- the write silently no-ops, because `write_component_value` guards with
  `hasattr`.

Nothing in CI notices, because no test resolves a description against the api of
the model that actually uses it.

## The guard

`tests/test_entity_descriptions.py`, 449 parametrised cases:

- `test_description_accessor_resolves` resolves every accessor lambda of every
  model specific description list against the api object that model's coordinator
  really builds, so `WpmStiebelEltronAPI`, `Wpm3iStiebelEltronAPI` or
  `LwzStiebelEltronAPI` over a mock Modbus connection. Real api instances rather
  than static introspection, so repeating group accessors such as
  `api.system_values.room_temperatures[0].actual_temperature` resolve too.
- `test_description_write_field_resolves` asserts every `write_field` exists on
  the `write_component` of that api.
- `test_every_description_is_covered` keeps the registry from going stale: it
  collects every module level description list of each platform module and fails
  if a description is in none of the registered lists. It matches on object
  identity, so composed lists such as
  `WPM_SENSOR_TYPES = SYSTEM_VALUES_SENSOR_TYPES + ...` are covered through their
  parent, while a genuinely new list has to be registered with the model that
  uses it. This replaces the hand maintained mapping that the Sourcery review
  flagged as a staleness risk.

Covered platforms: number, sensor, binary_sensor, switch, select and climate.
`button` is deliberately out of scope and says so in the file: its descriptions
carry a coordinator level `press_action` rather than an api accessor, and the
same list serves every model.

## Verified that it guards

- Reintroducing the old accessor name makes exactly the two affected
  descriptions fail, nothing else.
- Corrupting a `write_field` fails exactly that one case.
- Removing a list from the registry fails `test_every_description_is_covered`
  for that platform.
- Full suite on this branch: 494 passed, 4 skipped, the skips being the existing
  lingering timer ones from main. Ruff clean.

## One refactor in switch.py, no behaviour change

The circulation pump description was built inline inside `async_setup_entry`,
which put it out of the guard's reach. It moves to a module level
`CIRCULATION_PUMP_SWITCH_TYPES`. Its model condition is untouched, and it is
checked against the WPM api because both WPMsystem and LWZ_R290 are served by
that api.

## Deliberately not included

The write test only asserts the field exists, not that the library marks it
writable. A read-only target would still fail silently at `Component.write`. A
warning log on the `hasattr` miss in `write_component_value` would be a cheap
runtime net to go with this CI time guard, but that is a separate change.
