### PR TITLE
Make the WPM power-consumption sensors work: pin 0.6.0 and report 24 h windows in Wh

### DIFF
--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -197,16 +197,28 @@ def create_energy_entity_description(
 def create_power_consumption_entity_description(
     key: str,
     modbus_register: StiebelEltronModbusRegister,
+    native_unit: UnitOfEnergy = UnitOfEnergy.KILO_WATT_HOUR,
 ) -> StiebelEltronSensorEntityDescription:
-    """Create a power-consumption window sensor (rolling sum, resets over time).
+    """Create a sensor for one Servicewelt "POWER CONSUMPTION" window.
 
-    These are the Servicewelt "POWER CONSUMPTION" statistics. Because the
-    windows reset, they use ``TOTAL`` rather than ``TOTAL_INCREASING``.
+    The state class is a placeholder. Whether a window rolls continuously or
+    resets to zero is not established, and the two cases want different classes:
+    a reset-to-zero counter is what ``TOTAL_INCREASING`` is for, while a rolling
+    sum suits neither, since its long-term sum statistic would just drift. Until
+    someone samples a real machine over a day, ``TOTAL`` stays as the least bad
+    option. The presence of a "previous 12 months" register suggests these are
+    bucketed rolling sums rather than daily counters.
+
+    The unit is selected per window: the library sums each register pair as
+    ``low + high * 1000``, so the result carries the smaller of the two units
+    Servicewelt displays. The 24 h windows therefore come out in Wh and pass
+    ``native_unit`` explicitly, while the 12-month windows are kWh and use the
+    default.
     """
     return StiebelEltronSensorEntityDescription(
         key=key,
         translation_key=key,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        native_unit_of_measurement=native_unit,
         icon="mdi:meter-electric",
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.ENERGY,
@@ -1035,13 +1047,19 @@ WPM_COMPRESSOR_SENSOR_TYPES = [
     ),
 ]
 
-# Servicewelt "POWER CONSUMPTION" screen (Modbus registers 3707-3723). The
-# pystiebeleltron library already decodes each register pair into a kWh value,
-# so these read the plain energy_data fields.
+# Servicewelt "POWER CONSUMPTION" screen: nine register pairs spanning 3707-3724,
+# followed immediately by the efficiency block at 3725, which confirms the
+# nine-times-two layout leaves no gap. The
+# pystiebeleltron library decodes each register pair as ``low + high * 1000``,
+# which lands in Wh for the 24 h windows and in kWh for the 12-month ones. The
+# library's own field metadata claims kWh throughout, which is wrong for the
+# 24 h windows; the neighbouring amount-of-heat block declares Wh for its 24 h
+# entry with the same arithmetic.
 WPM_POWER_CONSUMPTION_SENSOR_TYPES = [
     create_power_consumption_entity_description(
         CONSUMED_HEATING_LAST_24H,
         lambda api: api.energy_data.heating_24h,
+        UnitOfEnergy.WATT_HOUR,
     ),
     create_power_consumption_entity_description(
         CONSUMED_HEATING_12M,
@@ -1054,6 +1072,7 @@ WPM_POWER_CONSUMPTION_SENSOR_TYPES = [
     create_power_consumption_entity_description(
         CONSUMED_COOLING_LAST_24H,
         lambda api: api.energy_data.cooling_24h,
+        UnitOfEnergy.WATT_HOUR,
     ),
     create_power_consumption_entity_description(
         CONSUMED_COOLING_12M,
@@ -1066,6 +1085,7 @@ WPM_POWER_CONSUMPTION_SENSOR_TYPES = [
     create_power_consumption_entity_description(
         CONSUMED_WATER_HEATING_LAST_24H,
         lambda api: api.energy_data.dhw_24h,
+        UnitOfEnergy.WATT_HOUR,
     ),
     create_power_consumption_entity_description(
         CONSUMED_WATER_HEATING_12M,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -71,36 +71,47 @@ def test_lwz_exposes_compressor_frequency() -> None:
 
 
 def test_wpm_exposes_power_consumption_statistics() -> None:
-    """WPM power-consumption windows read the 3707-3723 energy_data fields (kWh)."""
+    """WPM power-consumption windows read the 3707-3723 energy_data fields.
+
+    Each window is a register pair that the library sums as
+    ``low + high * 1000``, which yields the smaller of the two units the
+    Servicewelt screen displays: the 24 h windows come out in Wh (Servicewelt
+    shows kWh) and the 12-month windows in kWh (Servicewelt shows MWh). The
+    values below are the readings bartveenstra measured against Servicewelt on
+    a real WPMsystem while reverse engineering this block, see pull request
+    #544.
+    """
     api = SimpleNamespace(
         energy_data=SimpleNamespace(
             heating_24h=12,
-            heating_12m=3456,
+            heating_12m=7244,  # Servicewelt: 7.244 MWh
             heating_13_24=3210,
-            cooling_24h=1,
+            cooling_24h=1904,  # Servicewelt: 1.904 kWh
             cooling_12m=210,
             cooling_13_24=198,
-            dhw_24h=5,
+            dhw_24h=19574,  # Servicewelt: 19.574 kWh
             dhw_12m=1500,
             dhw_13_24=1450,
         )
     )
+    wh = UnitOfEnergy.WATT_HOUR
+    kwh = UnitOfEnergy.KILO_WATT_HOUR
     expected = {
-        CONSUMED_HEATING_LAST_24H: ("heating_24h", 12),
-        CONSUMED_HEATING_12M: ("heating_12m", 3456),
-        CONSUMED_HEATING_PREV_12M: ("heating_13_24", 3210),
-        CONSUMED_COOLING_LAST_24H: ("cooling_24h", 1),
-        CONSUMED_COOLING_12M: ("cooling_12m", 210),
-        CONSUMED_COOLING_PREV_12M: ("cooling_13_24", 198),
-        CONSUMED_WATER_HEATING_LAST_24H: ("dhw_24h", 5),
-        CONSUMED_WATER_HEATING_12M: ("dhw_12m", 1500),
-        CONSUMED_WATER_HEATING_PREV_12M: ("dhw_13_24", 1450),
+        CONSUMED_HEATING_LAST_24H: (12, wh),
+        CONSUMED_HEATING_12M: (7244, kwh),
+        CONSUMED_HEATING_PREV_12M: (3210, kwh),
+        CONSUMED_COOLING_LAST_24H: (1904, wh),
+        CONSUMED_COOLING_12M: (210, kwh),
+        CONSUMED_COOLING_PREV_12M: (198, kwh),
+        CONSUMED_WATER_HEATING_LAST_24H: (19574, wh),
+        CONSUMED_WATER_HEATING_12M: (1500, kwh),
+        CONSUMED_WATER_HEATING_PREV_12M: (1450, kwh),
     }
 
-    for key, (_field, value) in expected.items():
+    for key, (value, unit) in expected.items():
         desc = _wpm(key)
         assert desc.modbus_register(api) == value
-        assert desc.native_unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR
+        assert desc.native_unit_of_measurement == unit
         assert desc.device_class == SensorDeviceClass.ENERGY
         # Rolling windows reset, so they must not be TOTAL_INCREASING.
         assert desc.state_class == SensorStateClass.TOTAL


### PR DESCRIPTION
Follow-up to #584, which I authored. Two defects, deliberately in one PR because
shipping either half alone is worse than shipping neither.

On the released manifest the nine sensors cannot exist at all, and once they can,
three of them read a factor of 1000 too high. Releasing only the first half would
create the three wrong sensors and let them record bad long-term statistics before
the unit correction landed, so entity creation and correct units belong in the same
change. This supersedes #590, which I have closed.

# Part 1: the sensors never get created

`manifest.json` required `pystiebeleltron==0.5.1`, which is what Home Assistant
installs. `pyproject.toml` installs `0.6.0`, which is what the tests run against.

The nine sensors read `api.energy_data.heating_24h` and siblings. In 0.6.0 those
registers sit on `WpmEnergyData` as `scaled_sum` pairs; in 0.5.1 they live on a
separate `WpmPowerConsumption` component reached through `api.power_consumption`.
So on 0.5.1 every one of the nine accessors raises `AttributeError`, the
coordinator only catches `StiebelEltronModbusError`, and the entities are never
created. Same failure mode as #582. CI cannot see it, because CI installs 0.6.0.

This is the transition you described in #544: "In pystiebeleltron 0.6, the api has
slightly changed and the power consumption registers are now part of the energy
data." The integration was updated for it, the manifest was not. 6d28443 set the
exact-pin policy and 9639300 raised `pyproject.toml` and `uv.lock` but missed the
manifest, so the pin form is kept and only the version moves.

Verified by extracting the 0.5.1 wheel and resolving every accessor of every model
specific description list against it: only the power-consumption sensors fail, so
nothing else relied on the old pin. 0.6.0 only tightens its own transitive
`modbus-connection` requirement from `>=3.4.1` to `>=3.7.0`, and both resolve to
the `pymodbus` that Home Assistant constrains anyway.

`2026.7-beta3` is tagged at f47bee4, so the published prerelease carries the
mismatch. Might be worth a fresh beta once this is in. Stable is unaffected, since
`2026.2` is still latest.

The accompanying test asserts that the versions the tests actually run against are
admitted by the manifest requirements, skipping entries whose environment marker
does not apply. Its scope is documented as narrow on purpose: it is a drift guard,
not a compatibility proof, since it says nothing about the other versions a range
would admit.

# Part 2: the 24 hour windows are Wh, not kWh

## Problem

All nine power-consumption windows were declared `kWh`. The library sums each
register pair as `low + high * 1000`, so the result is expressed in the smaller
of the two units the Servicewelt screen uses:

- the 24 h windows come out in **Wh** (Servicewelt displays them in kWh)
- the 12-month windows come out in **kWh** (Servicewelt displays them in MWh)

So `consumed_heating_last_24h`, `consumed_cooling_last_24h` and
`consumed_water_heating_last_24h` were wrong; the six 12-month sensors were
already right.

## Evidence

Cross-checked against the readings @bartveenstra measured against Servicewelt on
a real WPMsystem while reverse engineering this block in #544:

| Servicewelt | fraction / whole | library result | unit that implies |
|---|---|---|---|
| Cooling 1-24 h: 1.904 kWh | 904 / 1 | 1904 | Wh |
| DHW 1-24 h: 19.574 kWh | 574 / 19 | 19574 | Wh |
| Heating 1-12 M: 7.244 MWh | 244 / 7 | 7244 | kWh |

Two independent corroborations:

1. `pystiebeleltron` itself declares the neighbouring amount-of-heat block with
   the same `scaled_sum(reg, (1, 1000))` weights but `unit="Wh"` for its 24 h
   entry and `unit="kWh"` for the 12-month entries, i.e. exactly this split.
2. The addresses reconcile. @bartveenstra's enum values look one higher than the
   library's `scaled_sum` bases, but the old library API labelled registers as
   `base_address + 1 + i`, so his "3714" is PDU 3713. Every one of his pairs then
   lands exactly on a current library field.

I also probed a live ISG read-only to confirm the current library addresses
registers directly (register 506 returned 191 for a real 19.1 C outdoor
temperature, 5001 returned the WPM_3i model code).

### Limits of the evidence, stated plainly

The heating 24 h window was **not** measured directly. @bartveenstra's enum treats
`HEATING_24H` as a single register and does not define PDU 3708 at all, while the
library reads 3707/3708 as a pair. That 3708 is the whole-kWh word follows from
the layout of the block, not from a measurement. If someone with the hardware can
post raw values for 3707 and 3708 alongside the Servicewelt reading, that would
close the last gap.

I could not verify any of this on my own unit: my WPM_3i does not implement
registers 3643 and above at all, they return ILLEGAL DATA ADDRESS.

## Note for the release notes

`Wh` and `kWh` are convertible, so Home Assistant keeps each entity's existing
display unit and converts the new native value. There is no incompatible-unit
error. But the already recorded history is not corrected, and the first corrected
sample produces a large negative delta in the long-term statistics of these three
sensors. Affected users should delete those three statistics via Developer Tools,
Statistics. These sensors only shipped in 2026.7-beta3, so the group should be
small.

## The state class needs your call

Two reviewers independently flagged that `TOTAL` is probably wrong for all nine
of these, and that the factory docstring I wrote in #584 argued it backwards: it
said "because the windows reset, they use TOTAL rather than TOTAL_INCREASING",
but a reset-to-zero counter is exactly the `TOTAL_INCREASING` case. I have
replaced that comment with an honest statement of the uncertainty rather than
silently changing behaviour.

The substance: if these windows roll continuously, `TOTAL` produces a long-term
sum statistic that just drifts, and no state class at all would be more honest
while `device_class=ENERGY` still handles units. If they reset daily,
`TOTAL_INCREASING` is the documented choice. So `TOTAL` is not right under either
reading, only least bad. The presence of a "previous 12 months" register argues
for bucketed rolling sums rather than daily counters.

I have not changed it here because I cannot test it: my WPM_3i does not implement
this register block at all. Sampling one real machine hourly for a day settles it.

Worth deciding in this PR rather than later, though, because anyone affected by
the unit change has to clean up these statistics anyway, and a separate state
class change would force a second cleanup. Happy to fold in whichever you prefer.

## Also flagged

`pystiebeleltron` declares `unit="kWh"` on the three 24 h fields, which is the
root of this confusion and inconsistent with the neighbouring amount-of-heat
fields in the same file. Issues are disabled on that repository, so flagging it
here: the metadata is misleading for any other consumer.

Fixing it upstream would not change Home Assistant on its own, because the unit
is set in this repo, so this PR is needed either way. Happy to send a library PR
for the metadata if you want it. A further step would be an integration test
asserting each entity's native unit matches the library field's declared unit,
which would make this class of bug structurally impossible, but that can only
land after the library metadata is correct.
