### PR TITLE
Fix duplicated LWZ solar heat-meter sensors

### DIFF
--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -838,7 +838,7 @@ LWZ_ENERGY_SENSOR_TYPES = [
     ),
     create_energy_entity_description(
         PRODUCED_SOLAR_HEATING,
-        lambda api: api.energy_data.hm_solar_htg_total,
+        lambda api: api.energy_data.hm_solar_htg_day_and_total,
     ),
     create_energy_entity_description(
         PRODUCED_SOLAR_HEATING_TOTAL,
@@ -850,7 +850,7 @@ LWZ_ENERGY_SENSOR_TYPES = [
     ),
     create_energy_entity_description(
         PRODUCED_SOLAR_WATER_HEATING,
-        lambda api: api.energy_data.hm_solar_dwh_total,
+        lambda api: api.energy_data.hm_solar_dhw_day_and_total,
     ),
 ]
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -19,6 +19,10 @@ from custom_components.stiebel_eltron_isg.const import (
     CONSUMED_WATER_HEATING_LAST_24H,
     CONSUMED_WATER_HEATING_PREV_12M,
     COOLING_RUNTIME,
+    PRODUCED_SOLAR_HEATING,
+    PRODUCED_SOLAR_HEATING_TOTAL,
+    PRODUCED_SOLAR_WATER_HEATING,
+    PRODUCED_SOLAR_WATER_HEATING_TOTAL,
 )
 from custom_components.stiebel_eltron_isg.sensor import (
     LWZ_SENSOR_TYPES,
@@ -104,3 +108,30 @@ def test_wpm_exposes_power_consumption_statistics() -> None:
         assert desc.device_class == SensorDeviceClass.ENERGY
         # Rolling windows reset, so they must not be TOTAL_INCREASING.
         assert desc.state_class == SensorStateClass.TOTAL
+
+
+def test_lwz_solar_sensors_are_not_duplicates() -> None:
+    """The plain LWZ solar keys track day+total, the Total keys the lifetime sum.
+
+    Note the library's inconsistent spelling: the lifetime register is
+    ``hm_solar_dwh_total`` (dwh) while the day and day+total fields use dhw.
+    """
+    api = SimpleNamespace(
+        energy_data=SimpleNamespace(
+            hm_solar_htg_day_and_total=1101,
+            hm_solar_htg_total=1100,
+            hm_solar_dhw_day_and_total=2202,
+            hm_solar_dwh_total=2200,
+        )
+    )
+    expected = {
+        PRODUCED_SOLAR_HEATING: 1101,
+        PRODUCED_SOLAR_HEATING_TOTAL: 1100,
+        PRODUCED_SOLAR_WATER_HEATING: 2202,
+        PRODUCED_SOLAR_WATER_HEATING_TOTAL: 2200,
+    }
+
+    values = {key: _lwz(key).modbus_register(api) for key in expected}
+    assert values == expected
+    # A duplicated accessor would collapse two of the four sensors.
+    assert len(set(values.values())) == 4


### PR DESCRIPTION
Fixes #581.

## Problem

Four LWZ solar sensors resolve to only two library fields, so two of them are
permanent duplicates of their `...Total` siblings:

| key | read before | read now |
|---|---|---|
| `produced_solar_heating` | `hm_solar_htg_total` | `hm_solar_htg_day_and_total` |
| `produced_solar_heating_total` | `hm_solar_htg_total` | unchanged |
| `produced_solar_water_heating` | `hm_solar_dwh_total` | `hm_solar_dhw_day_and_total` |
| `produced_solar_water_heating_total` | `hm_solar_dwh_total` | unchanged |

The plain keys are meant to track the running day-plus-total value, exactly as
the non-solar entries in the same list already do: `produced_heating` reads
`heat_meter_htg_day_and_total`, `produced_water_heating` reads
`heat_meter_dhw_day_and_total`, `produced_recovery` reads
`heat_m_recovery_day_and_total`.

Not a migration regression: the duplication predates the library migration, and
8eb1bae carried it across faithfully rather than introducing it.

## Statistics impact

None worth worrying about. `day_and_total` is always greater than or equal to
`total`, so the recorded `TOTAL_INCREASING` statistics see a single upward step
and never a reset, which means no negative-delta artifacts.

## Note on the library field names

The spelling is inconsistent upstream and the fix depends on it: the lifetime
register is `hm_solar_dwh_total` (dwh), while the day and day-plus-total fields
are `hm_solar_dhw_day` / `hm_solar_dhw_day_and_total` (dhw). The total accessor is
deliberately left as is.

## Test

Added a test that pins all four solar keys to four distinct values, so a
duplicated accessor cannot pass. It fails on `main` with the two plain keys
returning the total instead of day-plus-total.

`pytest`: 46 passed. `ruff check` and `ruff format --check`: clean.

## Also checked

`LWZ_ENERGY_DAILY_SENSOR_TYPES` has solar day entries too, so I audited it for the
same class of bug: all seven entries use distinct day accessors, no duplication
there. Nothing further to fix.
