### PR TITLE
Expose WPM electrical booster energy sensors

### DIFF
--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -785,6 +785,14 @@ ENERGY_SENSOR_TYPES = [
         CONSUMED_WATER_HEATING,
         lambda api: api.energy_data.vd_dhw_day_and_total_consumed,
     ),
+    create_energy_entity_description(
+        PRODUCED_ELECTRICAL_BOOSTER_HEATING_TOTAL,
+        lambda api: api.energy_data.nhz_heating_total,
+    ),
+    create_energy_entity_description(
+        PRODUCED_ELECTRICAL_BOOSTER_WATER_HEATING_TOTAL,
+        lambda api: api.energy_data.nhz_dhw_total,
+    ),
 ]
 
 LWZ_ENERGY_SENSOR_TYPES = [

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -19,6 +19,8 @@ from custom_components.stiebel_eltron_isg.const import (
     CONSUMED_WATER_HEATING_LAST_24H,
     CONSUMED_WATER_HEATING_PREV_12M,
     COOLING_RUNTIME,
+    PRODUCED_ELECTRICAL_BOOSTER_HEATING_TOTAL,
+    PRODUCED_ELECTRICAL_BOOSTER_WATER_HEATING_TOTAL,
 )
 from custom_components.stiebel_eltron_isg.sensor import (
     LWZ_SENSOR_TYPES,
@@ -29,6 +31,10 @@ from custom_components.stiebel_eltron_isg.sensor import (
 
 def _wpm(key: str):
     return next(d for d in WPM_SENSOR_TYPES if d.key == key)
+
+
+def _wpm_3i(key: str):
+    return next(d for d in WPM_3I_SENSOR_TYPES if d.key == key)
 
 
 def _lwz(key: str):
@@ -104,3 +110,27 @@ def test_wpm_exposes_power_consumption_statistics() -> None:
         assert desc.device_class == SensorDeviceClass.ENERGY
         # Rolling windows reset, so they must not be TOTAL_INCREASING.
         assert desc.state_class == SensorStateClass.TOTAL
+
+
+def test_wpm_exposes_electrical_booster_energy() -> None:
+    """WPM and WPM_3i expose the NHZ booster heat meters (3506/3508, kWh).
+
+    Without these the energy dashboard shows untracked consumption whenever
+    the immersion heater runs.
+    """
+    api = SimpleNamespace(
+        energy_data=SimpleNamespace(nhz_heating_total=417, nhz_dhw_total=93)
+    )
+    expected = {
+        PRODUCED_ELECTRICAL_BOOSTER_HEATING_TOTAL: 417,
+        PRODUCED_ELECTRICAL_BOOSTER_WATER_HEATING_TOTAL: 93,
+    }
+
+    for lookup in (_wpm, _wpm_3i):
+        for key, value in expected.items():
+            desc = lookup(key)
+            assert desc.modbus_register(api) == value
+            assert desc.native_unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR
+            assert desc.device_class == SensorDeviceClass.ENERGY
+            # Lifetime counters, not rolling windows.
+            assert desc.state_class == SensorStateClass.TOTAL_INCREASING


### PR DESCRIPTION
Fixes #489, and the earlier #349 that it refers to.

## Problem

WPM and WPM 3i expose no energy counter for the electric immersion heater (NHZ),
so the Home Assistant energy dashboard shows untracked consumption whenever the
booster runs. Since the booster is enabled by default, several users have hit
this and drawn wrong efficiency conclusions from it.

LWZ already has the two sensors; only the WPM side was missing.

## Change

Registers 3506 and 3508, `scaled_sum(reg, (1, 1000))`, kWh, wired into the shared
`ENERGY_SENSOR_TYPES` so both WPM and WPM 3i get them. The fields exist on the
library's `WpmEnergyData` and on the local `Wpm3iEnergyData`.

The constants and all translations already existed and were wired for LWZ only
(`heat_m_boost_htg_ttl` / `heat_m_boost_dhw_ttl`), so this needs no new keys and
no json changes at all. The two entity keys are therefore consistent across all
three controller families.

## One caveat worth stating

These registers report the heat *produced* by the immersion heater, not metered
electricity. For a resistive element the two are equivalent within the element's
tolerance, which is what the energy dashboard needs, but it is not a current
measurement.

This also partly answers the second half of #489: the produced-heat totals for
the compressor genuinely do not include the booster, so a COP computed from them
describes the heat pump alone, not the installation.

## Test

Asserts both keys appear for WPM and for WPM 3i, resolve to the right fields, and
carry kWh, `ENERGY` and `TOTAL_INCREASING` (lifetime counters, not rolling
windows).

`pytest`: 46 passed. `ruff check` and `ruff format --check`: clean.

## Not verified on hardware

My own unit reports 0 for both registers, which is a valid reading rather than an
error, so the values are untested against a machine that has actually run its
booster. Confirmation from someone whose immersion heater has run would be
welcome.

## Summary by Sourcery

Expose electrical booster energy sensors for WPM and WPM 3i to ensure immersion heater consumption appears correctly in energy tracking.

New Features:
- Add lifetime electrical booster heating and water heating energy sensors for WPM controllers using existing energy descriptions.

Tests:
- Add sensor tests verifying WPM and WPM 3i expose booster energy totals with correct units, device class, and TOTAL_INCREASING state class.