### PR TITLE
Pin pystiebeleltron 0.6.0 in the manifest

### DIFF
--- a/custom_components/stiebel_eltron_isg/manifest.json
+++ b/custom_components/stiebel_eltron_isg/manifest.json
@@ -19,7 +19,7 @@
     "pystiebeleltron"
   ],
   "requirements": [
-    "pystiebeleltron==0.5.1"
+    "pystiebeleltron==0.6.0"
   ],
   "version": "2025.7.0"
 }

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,51 @@
+"""Guards on the integration manifest.
+
+``manifest.json`` declares what Home Assistant installs at runtime. The test
+environment installs whatever ``pyproject.toml`` asks for. When the version the
+tests run against does not satisfy the manifest requirement, the whole suite can
+pass while the released integration is broken, which is how the WPM
+power-consumption sensors shipped against an API the pinned library did not have.
+
+The invariant asserted here is deliberately the weaker "what CI runs must be
+installable per the manifest" rather than "the two files agree exactly", so that
+a legitimate loosening of the manifest, for example to ``>=``, does not fail.
+"""
+
+import importlib.metadata
+import json
+from pathlib import Path
+
+from packaging.requirements import Requirement
+import pytest
+
+_MANIFEST = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "stiebel_eltron_isg"
+    / "manifest.json"
+)
+
+
+def test_installed_versions_satisfy_manifest_requirements() -> None:
+    """Every manifest requirement must be met by the environment CI tests on."""
+    requirements = json.loads(_MANIFEST.read_text())["requirements"]
+
+    assert requirements, "manifest declares no requirements"
+
+    for entry in requirements:
+        requirement = Requirement(entry)
+
+        try:
+            installed = importlib.metadata.version(requirement.name)
+        except importlib.metadata.PackageNotFoundError:
+            pytest.fail(
+                f"manifest.json requires {entry} but {requirement.name} is not "
+                f"installed in the test environment, so nothing here exercises "
+                f"the code that depends on it."
+            )
+
+        assert requirement.specifier.contains(installed, prereleases=True), (
+            f"manifest.json requires {entry} but the tests run against "
+            f"{requirement.name}=={installed}. Code relying on the installed "
+            f"version would fail only on a real installation, never in CI."
+        )


### PR DESCRIPTION
Follow-up to #584, which I authored. The nine sensors it added cannot work on a
real installation, independently of the unit problem in #587.

## Problem

`manifest.json` requires `pystiebeleltron==0.5.1`, which is what Home Assistant
installs. `pyproject.toml` installs `0.6.0`, which is what the test suite runs
against.

The nine sensors read `api.energy_data.heating_24h` and siblings. In 0.6.0 those
registers sit on `WpmEnergyData` as `scaled_sum` pairs. In 0.5.1 they live on a
separate `WpmPowerConsumption` component reached through `api.power_consumption`,
with individual `*_fraction` and `*_whole` integer fields. So on 0.5.1 every one
of the nine accessors raises `AttributeError`, the coordinator only catches
`StiebelEltronModbusError`, and the entities are never created. Same failure mode
as #582.

CI cannot see this, because CI installs 0.6.0.

This is the transition you described in #544: "In pystiebeleltron 0.6, the api has
slightly changed and the power consumption registers are now part of the energy
data." The integration was updated for it, the manifest was not.

## Verification

I extracted the 0.5.1 wheel and resolved every accessor of every model specific
description list, across all platforms, against it. Only the power-consumption
sensors fail, so nothing else in the integration relied on the old pin, and
bumping is safe.

0.6.0 tightens its own transitive requirement on `modbus-connection` from
`>=3.4.1` to `>=3.7.0`, which pip resolves normally. All tests pass against it.

## Note on the beta

`2026.7-beta3` is tagged at f47bee4, so the published prerelease carries the
mismatch and those nine entities are missing for anyone testing it. Might be worth
a fresh beta once this is in. The stable channel is unaffected, since `2026.2` is
still latest.

## The test

Rather than comparing `manifest.json` to `pyproject.toml`, it asserts that the
versions the tests actually run against satisfy the manifest requirements. That is
deliberately the weaker invariant: the manifest may legitimately loosen to a range
later, and this would not fail spuriously, while the thing that must never happen
again, CI passing against a version Home Assistant would not install, is still
caught. It iterates all manifest requirements, so it is not specific to this
library.

Verified it fails on the old pin and passes on the new one.

## Review status

Reviewed independently by one model, which found no risk in the bump. My usual
second reviewer was unavailable at the time (provider outage), so this has had one
independent review rather than two. Happy to hold if you would rather wait for
that.

## Summary by Sourcery

Align the integration’s runtime dependency on pystiebeleltron with the version used in development and CI to prevent sensors from relying on an unavailable API.

Build:
- Update the stiebel_eltron_isg manifest to require pystiebeleltron 0.6.0.

Tests:
- Add a manifest guard test that ensures all packages installed in the CI environment satisfy the integration’s manifest requirements.