### PR TITLE
Report written values immediately on number, select and climate

### DIFF
--- a/custom_components/stiebel_eltron_isg/climate.py
+++ b/custom_components/stiebel_eltron_isg/climate.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pystiebeleltron import ControllerModel
 
 from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
-from .entity import StiebelEltronISGEntity
+from .entity import OptimisticValueMixin, StiebelEltronISGEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -302,11 +302,16 @@ async def async_setup_entry(
     async_add_devices(entities)
 
 
-class StiebelEltronISGClimateEntity(StiebelEltronISGEntity, ClimateEntity):
+class StiebelEltronISGClimateEntity(
+    OptimisticValueMixin, StiebelEltronISGEntity, ClimateEntity
+):
     """stiebel_eltron_isg climate class."""
 
     _enable_turn_on_off_backwards_compatibility = False
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    # The field an assumed target temperature was written to, see
+    # ``target_temperature``.
+    _optimistic_target_field: str | None = None
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.PRESET_MODE
@@ -374,8 +379,23 @@ class StiebelEltronISGClimateEntity(StiebelEltronISGEntity, ClimateEntity):
         return None
 
     @property
+    def _target_temp_write_field(self) -> str | None:
+        """Return the field the current operating mode takes its target from."""
+        if self.operation_mode == ECO_MODE:
+            return self.eco_target_temp_write_field
+        return self.comfort_target_temp_write_field
+
+    @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
+        # An assumed target only holds for the field it was written to. Once the
+        # operating mode makes the other field the target, it no longer applies,
+        # whoever changed that mode.
+        if (
+            self._optimistic_value is not None
+            and self._optimistic_target_field == self._target_temp_write_field
+        ):
+            return self._optimistic_value
         if self.operation_mode == ECO_MODE:
             return self._read_accessor(self.eco_target_temp_register)
         return self._read_accessor(self.comfort_target_temp_register)
@@ -383,13 +403,11 @@ class StiebelEltronISGClimateEntity(StiebelEltronISGEntity, ClimateEntity):
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         value = kwargs["temperature"]
-        field = (
-            self.eco_target_temp_write_field
-            if self.operation_mode == ECO_MODE
-            else self.comfort_target_temp_write_field
-        )
+        field = self._target_temp_write_field
         if field is not None:
             await self._write_field(field, value)
+            self._optimistic_target_field = field
+            self._set_optimistic_value(value)
 
     def _read_accessor(self, accessor: Any) -> float | int | None:
         """Read a value via accessor callable."""

--- a/custom_components/stiebel_eltron_isg/coordinator.py
+++ b/custom_components/stiebel_eltron_isg/coordinator.py
@@ -80,6 +80,8 @@ class StiebelEltronDataCoordinator[T: StiebelEltronApi](DataUpdateCoordinator):
         self._host = params.host
         self._connection = params.connection
         self._api = api_client
+        self._refresh_generation = 0
+        self._last_successful_refresh_generation = 0
 
         super().__init__(
             hass,
@@ -152,12 +154,25 @@ class StiebelEltronDataCoordinator[T: StiebelEltronApi](DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[Any, float | int | None]:
         """Time to update."""
+        self._refresh_generation += 1
+        generation = self._refresh_generation
         try:
             await self._api.async_update()
         except ModbusError as exception:
             raise UpdateFailed(exception) from exception
         else:
+            self._last_successful_refresh_generation = generation
             return {}
+
+    @property
+    def refresh_generation(self) -> int:
+        """Return the generation of the newest started refresh."""
+        return self._refresh_generation
+
+    @property
+    def last_successful_refresh_generation(self) -> int:
+        """Return the generation of the newest successful refresh."""
+        return self._last_successful_refresh_generation
 
     def get_value(
         self,

--- a/custom_components/stiebel_eltron_isg/entity.py
+++ b/custom_components/stiebel_eltron_isg/entity.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import Any
 
+from homeassistant.core import callback
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -19,6 +20,44 @@ class StiebelEltronEntityDescription(EntityDescription):
     """Entity description for stiebel eltron with modbus register."""
 
     modbus_register: Any
+
+
+class OptimisticValueMixin:
+    """Report a written value right away, until the device reports its own.
+
+    A write travels ISG to CAN to heat pump and needs a moment to be reflected
+    in the registers, so an immediate read back would still return the old
+    value. The written value is therefore assumed until the coordinator has
+    polled again, at which point the device's own value takes over. If the
+    controller clamps or rounds the value, that correction appears with that
+    poll.
+
+    The mixin must precede ``CoordinatorEntity`` in the entity's MRO. It keeps
+    the assumption until a successful poll that started after the write, so a
+    poll already in flight cannot restore a value it read before the write.
+    """
+
+    _optimistic_value: float | int | None = None
+    _optimistic_after_generation: int | None = None
+
+    def _set_optimistic_value(self, value: float | int) -> None:
+        """Assume ``value`` until the device has been polled after the write."""
+        self._optimistic_value = value
+        self._optimistic_after_generation = self.coordinator.refresh_generation
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Hand the value back to the device once it has been polled."""
+        if (
+            self._optimistic_after_generation is not None
+            and self.coordinator.last_update_success
+            and self.coordinator.last_successful_refresh_generation
+            > self._optimistic_after_generation
+        ):
+            self._optimistic_value = None
+            self._optimistic_after_generation = None
+        super()._handle_coordinator_update()
 
 
 class StiebelEltronISGEntity(CoordinatorEntity[StiebelEltronDataCoordinator]):

--- a/custom_components/stiebel_eltron_isg/number.py
+++ b/custom_components/stiebel_eltron_isg/number.py
@@ -43,7 +43,7 @@ from .const import (
     HEATING_CURVE_RISE_HK3,
 )
 from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
-from .entity import StiebelEltronISGEntity
+from .entity import OptimisticValueMixin, StiebelEltronISGEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -526,7 +526,9 @@ async def async_setup_entry(
     async_add_devices(entities)
 
 
-class StiebelEltronISGNumberEntity(StiebelEltronISGEntity, NumberEntity):
+class StiebelEltronISGNumberEntity(
+    OptimisticValueMixin, StiebelEltronISGEntity, NumberEntity
+):
     """stiebel_eltron_isg select class."""
 
     def __init__(
@@ -557,7 +559,11 @@ class StiebelEltronISGNumberEntity(StiebelEltronISGEntity, NumberEntity):
         if self.write_field is None:
             return
 
-        current = self.coordinator.get_value(self.modbus_register)
+        current = (
+            self._optimistic_value
+            if self._optimistic_value is not None
+            else self.coordinator.get_value(self.modbus_register)
+        )
         if current is not None and math.isclose(current, value, abs_tol=1e-9):
             return
 
@@ -566,8 +572,11 @@ class StiebelEltronISGNumberEntity(StiebelEltronISGEntity, NumberEntity):
             self.write_field,
             value,
         )
+        self._set_optimistic_value(value)
 
     @property
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
+        if self._optimistic_value is not None:
+            return self._optimistic_value
         return self.coordinator.get_value(self.modbus_register)

--- a/custom_components/stiebel_eltron_isg/select.py
+++ b/custom_components/stiebel_eltron_isg/select.py
@@ -11,7 +11,7 @@ from pystiebeleltron import ControllerModel
 
 from .const import OPERATION_MODE
 from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
-from .entity import StiebelEltronISGEntity
+from .entity import OptimisticValueMixin, StiebelEltronISGEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -120,7 +120,9 @@ def get_key_from_value(d: dict[int, str], val: str) -> int | None:
     return None
 
 
-class StiebelEltronISGSelectEntity(StiebelEltronISGEntity, SelectEntity):
+class StiebelEltronISGSelectEntity(
+    OptimisticValueMixin, StiebelEltronISGEntity, SelectEntity
+):
     """stiebel_eltron_isg select class."""
 
     def __init__(
@@ -145,7 +147,11 @@ class StiebelEltronISGSelectEntity(StiebelEltronISGEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return current option."""
-        value = self.coordinator.get_value(self.modbus_register)
+        value = (
+            self._optimistic_value
+            if self._optimistic_value is not None
+            else self.coordinator.get_value(self.modbus_register)
+        )
         key = int(value) if value is not None else None
         if key is None:
             return None
@@ -160,3 +166,4 @@ class StiebelEltronISGSelectEntity(StiebelEltronISGEntity, SelectEntity):
                 self.write_field,
                 key,
             )
+            self._set_optimistic_value(key)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from homeassistant.components.climate import ClimateEntityFeature
 from homeassistant.components.climate.const import FAN_HIGH, FAN_LOW
+import pytest
 
 from custom_components.stiebel_eltron_isg.climate import (
     ECO_MODE,
@@ -47,6 +48,8 @@ class _FakeSystemParameters:
         self.operating_mode = operating_mode
         self.day_stage = day_stage
         self.night_stage = night_stage
+        self.room_temperature_day_hk1 = 21.0
+        self.room_temperature_night_hk1 = 18.0
 
 
 class _FakeApi:
@@ -60,6 +63,9 @@ class _StubCoordinator:
     def __init__(self, api) -> None:
         self._api = api
         self.writes: list[tuple] = []
+        self.refresh_generation = 0
+        self.last_successful_refresh_generation = 0
+        self.last_update_success = True
         # The real DataUpdateCoordinator caches nothing of its own; ``data`` is
         # an empty dict. The old code queried it with a string key and always
         # missed, which is exactly the bug under test.
@@ -79,6 +85,21 @@ def _make_lwz_climate(
     api = _FakeApi(_FakeSystemParameters(operating_mode, day_stage, night_stage))
     entity.coordinator = _StubCoordinator(api)
     entity.write_component = "system_parameters"
+    entity.eco_target_temp_write_field = "room_temperature_night_hk1"
+    entity.comfort_target_temp_write_field = "room_temperature_day_hk1"
+    entity.eco_target_temp_register = lambda api: (
+        api.system_parameters.room_temperature_night_hk1
+    )
+    entity.comfort_target_temp_register = lambda api: (
+        api.system_parameters.room_temperature_day_hk1
+    )
+    # Written state is pushed to hass, which does not exist in these unit tests.
+    entity.published_states = 0
+
+    def _publish() -> None:
+        entity.published_states += 1
+
+    entity.async_write_ha_state = _publish
     return entity
 
 
@@ -112,3 +133,93 @@ async def test_lwz_set_fan_mode_writes_day_stage_when_not_eco() -> None:
     await entity.async_set_fan_mode(FAN_HIGH)
 
     assert entity.coordinator.writes == [("system_parameters", "day_stage", 3)]
+
+
+async def test_climate_shows_written_target_before_the_next_poll() -> None:
+    """A written target must be reported at once, not only after the next poll."""
+    entity = _make_lwz_climate(operating_mode=3)
+
+    await entity.async_set_temperature(temperature=22.5)
+
+    assert entity.coordinator.writes == [
+        ("system_parameters", "room_temperature_day_hk1", 22.5)
+    ]
+    assert entity.target_temperature == 22.5
+    assert entity.published_states == 1
+
+
+async def test_climate_does_not_assume_a_target_when_the_write_fails() -> None:
+    """A failed write must leave the device's reported target in place."""
+    entity = _make_lwz_climate(operating_mode=3)
+
+    async def failed_write(component, field, value) -> None:
+        raise RuntimeError("write failed")
+
+    entity.coordinator.write_component_value = failed_write
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        await entity.async_set_temperature(temperature=22.5)
+
+    assert entity.target_temperature == 21.0
+
+
+async def test_climate_returns_to_the_device_value_once_polled() -> None:
+    """A poll made after the write must hand the target back to the device."""
+    entity = _make_lwz_climate(operating_mode=3)
+    entity.coordinator.refresh_generation = 1
+    await entity.async_set_temperature(temperature=22.5)
+
+    # This poll started before the write and may have read the old registers.
+    entity.coordinator.last_successful_refresh_generation = 1
+    entity._handle_coordinator_update()
+    assert entity.target_temperature == 22.5
+
+    entity.coordinator.refresh_generation = 2
+    entity.coordinator.last_successful_refresh_generation = 2
+    entity._handle_coordinator_update()
+
+    assert entity.target_temperature == 21.0
+
+
+async def test_climate_keeps_assumption_when_refresh_fails() -> None:
+    """A failed refresh has no new device value and must not clear the write."""
+    entity = _make_lwz_climate(operating_mode=3)
+    await entity.async_set_temperature(temperature=22.5)
+    entity.coordinator.refresh_generation = 1
+    entity.coordinator.last_update_success = False
+
+    entity._handle_coordinator_update()
+
+    assert entity.target_temperature == 22.5
+
+
+async def test_climate_drops_the_assumed_target_when_the_mode_makes_it_stale() -> None:
+    """An assumed target only holds for the field it was written to."""
+    entity = _make_lwz_climate(operating_mode=3)
+    await entity.async_set_temperature(temperature=22.5)
+
+    # Whoever changed it: in eco mode the target comes from the eco field, and
+    # the assumed value belongs to the comfort field.
+    entity.coordinator._api.system_parameters.operating_mode = ECO_MODE
+
+    assert entity.target_temperature == 18.0
+
+
+async def test_climate_keeps_the_assumed_target_when_the_fan_stage_changes() -> None:
+    """A fan stage write leaves the target field untouched."""
+    entity = _make_lwz_climate(operating_mode=3)
+    await entity.async_set_temperature(temperature=22.5)
+
+    await entity.async_set_fan_mode(FAN_LOW)
+
+    assert entity.target_temperature == 22.5
+
+
+async def test_climate_keeps_the_assumed_target_between_non_eco_modes() -> None:
+    """Both modes read the target from the comfort field, so it still holds."""
+    entity = _make_lwz_climate(operating_mode=3)
+    await entity.async_set_temperature(temperature=22.5)
+
+    entity.coordinator._api.system_parameters.operating_mode = 2
+
+    assert entity.target_temperature == 22.5

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from modbus_connection import ModbusError
 from pystiebeleltron import ControllerModel, StiebelEltronModbusError
 import pytest
@@ -134,6 +135,26 @@ def test_get_value_only_accepts_numeric_states(value, expected) -> None:
     coordinator = _coordinator(SimpleNamespace(value=value))
 
     assert coordinator.get_value(lambda api: api.value) == expected
+
+
+async def test_refresh_generations_only_advance_success_after_read() -> None:
+    """Entities can distinguish an old or failed poll from fresh device data."""
+    api = SimpleNamespace(async_update=AsyncMock())
+    coordinator = _coordinator(api)
+    coordinator._refresh_generation = 0
+    coordinator._last_successful_refresh_generation = 0
+
+    await coordinator._async_update_data()
+
+    assert coordinator.refresh_generation == 1
+    assert coordinator.last_successful_refresh_generation == 1
+
+    api.async_update.side_effect = ModbusError("read failed")
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    assert coordinator.refresh_generation == 2
+    assert coordinator.last_successful_refresh_generation == 1
 
 
 async def test_write_component_value_writes_supported_field() -> None:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -111,6 +111,25 @@ async def test_number_shows_written_value_before_the_next_poll() -> None:
     assert entity.native_value == 12.0
 
 
+async def test_number_repeated_optimistic_value_is_a_noop() -> None:
+    """Repeating the visible value must neither write nor delay reconciliation."""
+    entity = _make_number(current=10.0)
+
+    await entity.async_set_native_value(12.0)
+    entity.coordinator.refresh_generation = 1
+    await entity.async_set_native_value(12.0)
+
+    assert entity.coordinator.writes == [
+        ("system_parameters", "set_flow_temperature_area", 12.0)
+    ]
+
+    entity.coordinator._current = 11.0
+    entity.coordinator.last_successful_refresh_generation = 1
+    entity._handle_coordinator_update()
+
+    assert entity.native_value == 11.0
+
+
 async def test_number_can_return_to_device_value_before_the_next_poll() -> None:
     """A correction must be compared with the visible optimistic value."""
     entity = _make_number(current=10.0)
@@ -153,6 +172,25 @@ async def test_number_uses_the_first_poll_started_after_the_write() -> None:
     entity.coordinator.refresh_generation = 1
     entity.coordinator.last_successful_refresh_generation = 1
 
+    entity._handle_coordinator_update()
+
+    assert entity.native_value == 11.0
+
+
+async def test_number_keeps_optimistic_value_when_refresh_fails() -> None:
+    """A failed poll has no fresh device value to replace the written value."""
+    entity = _make_number(current=10.0)
+    await entity.async_set_native_value(12.0)
+
+    entity.coordinator.refresh_generation = 1
+    entity.coordinator.last_update_success = False
+    entity._handle_coordinator_update()
+
+    assert entity.native_value == 12.0
+
+    entity.coordinator._current = 11.0
+    entity.coordinator.last_update_success = True
+    entity.coordinator.last_successful_refresh_generation = 1
     entity._handle_coordinator_update()
 
     assert entity.native_value == 11.0

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 
 from pystiebeleltron.lwz import LwzSystemParameters
+import pytest
 
 from custom_components.stiebel_eltron_isg.const import (
     AREA_COOLING_FLOW_TEMPERATURE_HYSTERESIS,
@@ -23,6 +24,9 @@ class _StubCoordinator:
     def __init__(self, current: float | None) -> None:
         self._current = current
         self.writes: list[tuple] = []
+        self.refresh_generation = 0
+        self.last_successful_refresh_generation = 0
+        self.last_update_success = True
 
     def get_value(self, accessor) -> float | None:
         return self._current
@@ -37,6 +41,8 @@ def _make_number(current: float | None) -> StiebelEltronISGNumberEntity:
     entity.modbus_register = lambda api: None
     entity.write_component = "system_parameters"
     entity.write_field = "set_flow_temperature_area"
+    # Written state is pushed to hass, which does not exist in these unit tests.
+    entity.async_write_ha_state = lambda: None
     return entity
 
 
@@ -94,6 +100,78 @@ async def test_number_without_write_field_does_not_write() -> None:
     await entity.async_set_native_value(12.0)
 
     assert entity.coordinator.writes == []
+
+
+async def test_number_shows_written_value_before_the_next_poll() -> None:
+    """A written value must be reported at once, not only after the next poll."""
+    entity = _make_number(current=10.0)
+
+    await entity.async_set_native_value(12.0)
+
+    assert entity.native_value == 12.0
+
+
+async def test_number_can_return_to_device_value_before_the_next_poll() -> None:
+    """A correction must be compared with the visible optimistic value."""
+    entity = _make_number(current=10.0)
+
+    await entity.async_set_native_value(12.0)
+    await entity.async_set_native_value(10.0)
+
+    assert entity.coordinator.writes == [
+        ("system_parameters", "set_flow_temperature_area", 12.0),
+        ("system_parameters", "set_flow_temperature_area", 10.0),
+    ]
+    assert entity.native_value == 10.0
+
+
+async def test_number_returns_to_the_device_value_once_polled() -> None:
+    """A poll made after the write must hand the value back to the device."""
+    entity = _make_number(current=10.0)
+    entity.coordinator.refresh_generation = 1
+    await entity.async_set_native_value(12.0)
+
+    # The controller clamped the value, which a later poll reports.
+    entity.coordinator._current = 11.0
+
+    entity.coordinator.last_successful_refresh_generation = 1
+    entity._handle_coordinator_update()
+    assert entity.native_value == 12.0
+
+    entity.coordinator.refresh_generation = 2
+    entity.coordinator.last_successful_refresh_generation = 2
+    entity._handle_coordinator_update()
+
+    assert entity.native_value == 11.0
+
+
+async def test_number_uses_the_first_poll_started_after_the_write() -> None:
+    """Without an in-flight poll, the next successful poll is authoritative."""
+    entity = _make_number(current=10.0)
+    await entity.async_set_native_value(12.0)
+    entity.coordinator._current = 11.0
+    entity.coordinator.refresh_generation = 1
+    entity.coordinator.last_successful_refresh_generation = 1
+
+    entity._handle_coordinator_update()
+
+    assert entity.native_value == 11.0
+
+
+async def test_number_does_not_assume_a_value_it_did_not_write() -> None:
+    """A failed write must not change the reported value."""
+    entity = _make_number(current=10.0)
+    entity.coordinator.write_component_value = _failed_write
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        await entity.async_set_native_value(12.0)
+
+    assert entity.native_value == 10.0
+
+
+async def _failed_write(component, field, value) -> None:
+    """Stand in for a coordinator write that raises its translated error."""
+    raise RuntimeError("write failed")
 
 
 def _description(key: str):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,97 @@
+"""Tests for the select platform."""
+
+import pytest
+
+from custom_components.stiebel_eltron_isg.select import StiebelEltronISGSelectEntity
+
+_OPTIONS = {0: "off", 1: "eco", 2: "comfort"}
+
+
+class _StubCoordinator:
+    """Minimal coordinator stub exposing the value accessor API."""
+
+    def __init__(self, current: int | None) -> None:
+        self._current = current
+        self.writes: list[tuple] = []
+        self.refresh_generation = 0
+        self.last_successful_refresh_generation = 0
+        self.last_update_success = True
+
+    def get_value(self, accessor) -> int | None:
+        return self._current
+
+    async def write_component_value(self, component, field, value) -> None:
+        self.writes.append((component, field, value))
+
+
+def _make_select(current: int | None) -> StiebelEltronISGSelectEntity:
+    entity = StiebelEltronISGSelectEntity.__new__(StiebelEltronISGSelectEntity)
+    entity.coordinator = _StubCoordinator(current)
+    entity._options = _OPTIONS
+    entity.modbus_register = lambda api: None
+    entity.write_component = "system_parameters"
+    entity.write_field = "operating_mode"
+    # Written state is pushed to hass, which does not exist in these unit tests.
+    entity.async_write_ha_state = lambda: None
+    return entity
+
+
+async def test_select_writes_the_key_of_the_option() -> None:
+    """Selecting an option must write the key that option maps to."""
+    entity = _make_select(current=0)
+
+    await entity.async_select_option("comfort")
+
+    assert entity.coordinator.writes == [("system_parameters", "operating_mode", 2)]
+
+
+async def test_select_shows_written_option_before_the_next_poll() -> None:
+    """A selected option must be reported at once, not only after the next poll."""
+    entity = _make_select(current=0)
+
+    await entity.async_select_option("comfort")
+
+    assert entity.current_option == "comfort"
+
+
+async def test_select_returns_to_the_device_value_once_polled() -> None:
+    """A poll made after the write must hand the option back to the device."""
+    entity = _make_select(current=0)
+    entity.coordinator.refresh_generation = 1
+    await entity.async_select_option("comfort")
+
+    entity.coordinator.last_successful_refresh_generation = 1
+    entity._handle_coordinator_update()
+    assert entity.current_option == "comfort"
+
+    # The controller rejected the mode and stayed where it was.
+    entity.coordinator.refresh_generation = 2
+    entity.coordinator.last_successful_refresh_generation = 2
+    entity._handle_coordinator_update()
+
+    assert entity.current_option == "off"
+
+
+async def test_select_does_not_assume_an_option_it_did_not_write() -> None:
+    """A failed write must not change the reported option."""
+    entity = _make_select(current=0)
+
+    async def failed_write(component, field, value) -> None:
+        raise RuntimeError("write failed")
+
+    entity.coordinator.write_component_value = failed_write
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        await entity.async_select_option("comfort")
+
+    assert entity.current_option == "off"
+
+
+async def test_select_ignores_an_unknown_option() -> None:
+    """An option outside the mapping must not write anything."""
+    entity = _make_select(current=0)
+
+    await entity.async_select_option("does not exist")
+
+    assert entity.coordinator.writes == []
+    assert entity.current_option == "off"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -72,6 +72,24 @@ async def test_select_returns_to_the_device_value_once_polled() -> None:
     assert entity.current_option == "off"
 
 
+async def test_select_keeps_optimistic_option_when_refresh_fails() -> None:
+    """A failed poll has no fresh device option to replace the selected one."""
+    entity = _make_select(current=0)
+    await entity.async_select_option("comfort")
+
+    entity.coordinator.refresh_generation = 1
+    entity.coordinator.last_update_success = False
+    entity._handle_coordinator_update()
+
+    assert entity.current_option == "comfort"
+
+    entity.coordinator.last_update_success = True
+    entity.coordinator.last_successful_refresh_generation = 1
+    entity._handle_coordinator_update()
+
+    assert entity.current_option == "off"
+
+
 async def test_select_does_not_assume_an_option_it_did_not_write() -> None:
     """A failed write must not change the reported option."""
     entity = _make_select(current=0)


### PR DESCRIPTION
A write travels ISG to CAN to heat pump. Reading the register back right away
still returns the old value, so a slider or dropdown jumped back to its previous
position and only moved to the new one at the next poll. The fix is to show the
written value until the device has actually been polled after the write.

## Changes

- `entity.py`: `OptimisticValueMixin` keeps the written value and drops it on the
  first successful refresh that *started after* the write. A poll that was
  already in flight read the register before the write, so it must not be allowed
  to restore the old value.
- `coordinator.py`: a refresh generation counter, plus the generation of the last
  successful refresh, which is what the mixin compares against. This is
  deliberately not a timestamp; only ordering matters here.
- `number.py`, `select.py`: read the assumed value in `native_value` and
  `current_option` until the poll takes over.
- `climate.py`: the assumed target temperature is bound to the field it was
  written to. When the operating mode switches the target between the comfort and
  eco field, the assumption no longer applies, no matter who changed the mode.

The correction case is covered as well: the write deduplication that exists to
avoid pointless EEPROM writes now compares against the assumed value, not
against the register. Setting 45, noticing the mistake and setting the old 40
back before the next poll therefore still writes, instead of being dropped as a
no-op because the device happened to still report 40.

If the controller clamps or rounds a value, that correction appears with the next
poll, which is the earliest point at which it is known.

## Tests

- Number, select and climate: the value is reported at once, a stale in-flight
  poll does not overwrite it, and a later successful poll hands control back to
  the device.
- Climate: the assumed target is dropped when the mode makes the other field the
  target.
- Number: writing back to the previous device value before the poll is not
  swallowed by the deduplication.
- Coordinator: the generation counters advance only as described, in particular no
  successful generation on a failed update.

No dependency changes.
Part of #629.

## Summary by Sourcery

Report recently written values optimistically for number, select, and climate entities until a fresh successful poll confirms the device state, avoiding UI jumps and handling in‑flight or failed updates correctly.

New Features:
- Introduce an OptimisticValueMixin for entities to expose written values immediately and revert to device-reported values after a later successful refresh.
- Apply optimistic value handling to climate target temperature, number entities, and select entities so sliders and dropdowns reflect user changes instantly.

Bug Fixes:
- Prevent stale in-flight polls from overwriting freshly written values by tracking refresh generations in the data coordinator.
- Ensure write deduplication for number entities compares against the currently assumed value so quick corrections are not treated as no-ops.
- Avoid changing reported values or options when writes fail, keeping the device’s last known state.

Enhancements:
- Add generation counters to the data coordinator to distinguish fresh device data from older or failed polls.
- Refine climate target handling so optimistic assumptions are tied to the correct comfort/eco field and cleared when the operating mode makes them stale.

Tests:
- Add unit tests for climate, number, and select entities covering optimistic reporting, generation-based refresh behavior, write failures, and mode changes.
- Add coordinator tests verifying refresh generation and last successful generation advancement semantics.