### PR TITLE
Offer the active error sensor on a WPM 3i as well

### DIFF
--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -407,6 +407,13 @@ WPM_3I_SYSTEM_VALUES_SENSOR_TYPES = [
     create_pressure_entity_description(
         LOW_PRESSURE, lambda api: api.system_values.low_pressure
     ),
+    StiebelEltronSensorEntityDescription(
+        key=ACTIVE_ERROR,
+        translation_key=ACTIVE_ERROR,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:alert-circle",
+        modbus_register=lambda api: api.system_state.active_error,
+    ),
 ]
 
 SYSTEM_VALUES_SENSOR_TYPES = [

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -94,10 +94,45 @@ _DESCRIPTION_LISTS: list[tuple[str, str, list[Any]]] = [
 ]
 
 
+# The WPM list and the WPM 3i list a platform keeps for the same entities. The
+# 3i profile is a subset of the WPM one, so every pair is a parity candidate.
+_PARITY_CASES = [
+    pytest.param(name, wpm, wpm_3i, id=name)
+    for name, wpm, wpm_3i in (
+        ("sensor", sensor.WPM_SENSOR_TYPES, sensor.WPM_3I_SENSOR_TYPES),
+        (
+            "binary_sensor",
+            binary_sensor.WPM_BINARY_SENSOR_TYPES,
+            binary_sensor.WPM_3I_BINARY_SENSOR_TYPES,
+        ),
+        ("number", number.NUMBER_TYPES_WPM, number.NUMBER_TYPES_WPM_3I),
+        ("climate", climate.WPM_CLIMATE_TYPES, climate.WPM_3I_CLIMATE_TYPES),
+    )
+]
+
+
 @cache
 def _api(model: str) -> Any:
     """Return the API object a coordinator builds for ``model``."""
     return _API_CLASSES[model](MockModbusConnection().for_unit(UNIT_ID))
+
+
+def _resolves_on_wpm_3i(description: Any) -> bool:
+    """Return whether every accessor of ``description`` resolves on the 3i api."""
+    accessors = [
+        accessor
+        for attribute in _ACCESSOR_ATTRIBUTES
+        for value in [getattr(description, attribute, None)]
+        if value is not None
+        for accessor in (value if isinstance(value, list) else [value])
+    ]
+
+    try:
+        for accessor in accessors:
+            accessor(_api(WPM_3I))
+    except AttributeError:
+        return False
+    return bool(accessors)
 
 
 def _module_description_lists(module: ModuleType) -> list[tuple[str, list[Any]]]:
@@ -171,6 +206,31 @@ def test_description_write_field_resolves(
     assert component_object is not None, f"{model} api has no component {component}"
     assert hasattr(component_object, field), (
         f"{type(component_object).__name__} has no field {field}"
+    )
+
+
+@pytest.mark.parametrize(("list_name", "wpm", "wpm_3i"), _PARITY_CASES)
+def test_wpm_3i_offers_what_its_api_supports(
+    list_name: str, wpm: list[Any], wpm_3i: list[Any]
+) -> None:
+    """A WPM entity the WPM 3i api can serve has to be offered to the 3i too.
+
+    The 3i lists are curated rather than derived, so an entity added to the WPM
+    list stays invisible on a 3i until someone remembers the second list. That
+    is silent: nothing raises, the entity simply never appears. Whether the 3i
+    api resolves the accessor is the same test the coordinator would fail on,
+    so it decides here which entities the 3i is entitled to.
+    """
+    offered = {description.key for description in wpm_3i}
+
+    missing = sorted(
+        description.key
+        for description in wpm
+        if description.key not in offered and _resolves_on_wpm_3i(description)
+    )
+
+    assert not missing, (
+        f"{list_name} entities the WPM 3i api supports but the 3i list omits: {missing}"
     )
 
 


### PR DESCRIPTION
## What

A WPM 3i has no Active Error sensor. `WPM_3I_SENSOR_TYPES` is curated rather than derived from the WPM list, and `ACTIVE_ERROR` never made it across: it sits only in `SYSTEM_VALUES_SENSOR_TYPES`.

The register is there. `Wpm3iSystemState.active_error` is address 2506, inside the block the coordinator reads every round, so exposing it costs no extra Modbus traffic. Verified read only against a live WPM 3i: it answers 2506 with 0, no fault pending. The documentation lists ACTIVE ERROR for WPMsystem, WPM 3 and WPM 3i alike.

Until now a 3i only had the `error_status` binary sensor, which says whether something is wrong but not what.

## The test matters more than the fix

`test_wpm_3i_offers_what_its_api_supports` states the rule the curated list keeps breaking: an entity the WPM offers has to reach the 3i as well whenever the 3i API can resolve its accessor. Whether it resolves is the same check the coordinator would fail on, so it decides which entities the 3i is entitled to rather than a hand-kept list.

It fails on `active_error` alone across sensor, binary_sensor, number and climate, so nothing else is missing today, and the next entity added to a WPM list cannot go missing on the 3i in silence.

## Checks

530 tests, `ruff` clean. Rebased on current `main`.

## Summary by Sourcery

Expose the WPM 3i active error value as a diagnostic sensor and add safeguards to keep WPM 3i entity lists aligned with what its API actually supports.

New Features:
- Add an ACTIVE_ERROR diagnostic sensor entity for WPM 3i based on the system_state.active_error register.

Tests:
- Introduce a parity test ensuring each WPM entity whose accessor resolves on the WPM 3i API is also offered in the corresponding WPM 3i entity list across sensor, binary_sensor, number, and climate platforms.