### PR TITLE
Read the WPM 3i HK1 setpoint from the register the machine answers

### DIFF
--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -320,7 +320,7 @@ WPM_3I_SYSTEM_VALUES_SENSOR_TYPES = [
     ),
     create_temperature_entity_description(
         TARGET_TEMPERATURE_HK1,
-        lambda api: api.system_values.set_temperature_hk_1_wpm3i,
+        lambda api: api.system_values.set_temperature_hk_1,
     ),
     create_temperature_entity_description(
         ACTUAL_TEMPERATURE_HK2,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from pystiebeleltron.wpm import (
     WpmEnergyData,
     WpmEnergyManagementSettings,
     WpmEnergySystemInformation,
+    WpmExtendedEnergyData,
     WpmSystemParameters,
     WpmSystemState,
     WpmSystemValues,
@@ -143,6 +144,12 @@ def mock_wpm_api() -> Generator[MagicMock]:
         )
         type(api_client).energy_data = PropertyMock(
             return_value=MagicMock(spec=WpmEnergyData)
+        )
+        # The optional components are built in the API constructor, so autospec
+        # does not know them and every accessor on them would raise
+        # AttributeError, which silently drops those entities.
+        type(api_client).extended_energy_data = PropertyMock(
+            return_value=MagicMock(spec=WpmExtendedEnergyData)
         )
         type(api_client).system_state = PropertyMock(
             return_value=MagicMock(spec=WpmSystemState)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from modbus_connection import ModbusError, ModbusTimeoutError
 from modbus_connection.mock import MockModbusConnection
 from pystiebeleltron import StiebelEltronModbusError, UnknownControllerModelError
@@ -12,6 +13,8 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.stiebel_eltron_isg.const import DOMAIN
+from custom_components.stiebel_eltron_isg.entity import build_unique_id
+from custom_components.stiebel_eltron_isg.sensor import WPM_SENSOR_TYPES
 
 
 async def test_async_setup_entry_success(
@@ -24,6 +27,38 @@ async def test_async_setup_entry_success(
 
     assert result is True
     assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_setup_registers_every_wpm_sensor(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Every WPM sensor description has to end up with a state.
+
+    An accessor that raises AttributeError, which is what an API mock missing
+    one of the optional components does, still reaches the entity registry but
+    fails while being added, so it never gets a state. Nothing else in the
+    suite notices that, which is why the power-consumption windows silently
+    vanished when they moved to the optional extended_energy_data component.
+    This guards the fixture as much as the code.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_ids = {
+        entry.unique_id: entry.entity_id
+        for entry in er.async_entries_for_config_entry(
+            er.async_get(hass), mock_config_entry.entry_id
+        )
+    }
+    stateless = []
+    for description in WPM_SENSOR_TYPES:
+        entity_id = entity_ids.get(build_unique_id(mock_config_entry, description.key))
+        if entity_id is None or hass.states.get(entity_id) is None:
+            stateless.append(description.key)
+
+    assert not stateless, f"These sensors never got a state: {sorted(stateless)}"
 
 
 async def test_async_setup_entry_with_custom_port(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -26,6 +26,7 @@ from custom_components.stiebel_eltron_isg.const import (
     PRODUCED_SOLAR_HEATING_TOTAL,
     PRODUCED_SOLAR_WATER_HEATING,
     PRODUCED_SOLAR_WATER_HEATING_TOTAL,
+    TARGET_TEMPERATURE_HK1,
 )
 from custom_components.stiebel_eltron_isg.sensor import (
     LWZ_SENSOR_TYPES,
@@ -71,6 +72,25 @@ def test_wpm_3i_exposes_compressor_runtime_hours() -> None:
     assert {COMPRESSOR_HEATING, COMPRESSOR_HEATING_WATER, COOLING_RUNTIME} <= keys
 
 
+def test_wpm_3i_target_temperature_hk1_reads_the_shared_field() -> None:
+    """WPM_3i reads the HK1 setpoint from set_temperature_hk_1 (wire 509).
+
+    The Modbus manual assigns doc register 509 to the WPM 3i and doc 510 to the
+    WPM 3, but a real WPM 3i answers the HK1 setpoint on doc 510 / wire 509, the
+    address the WPM models use. Library pull request #63 therefore added
+    ``set_temperature_hk_1`` next to the older ``set_temperature_hk_1_wpm3i``
+    (wire 508), and this entity has to read the measured one, see issue #601.
+    """
+    api = SimpleNamespace(
+        system_values=SimpleNamespace(
+            set_temperature_hk_1=23.4,
+            set_temperature_hk_1_wpm3i=999.9,
+        )
+    )
+
+    assert _wpm_3i(TARGET_TEMPERATURE_HK1).modbus_register(api) == 23.4
+
+
 def test_lwz_exposes_compressor_frequency() -> None:
     """LWZ compressor frequency reads system_values.compressor_speed (Hz)."""
     api = SimpleNamespace(system_values=SimpleNamespace(compressor_speed=31.0))
@@ -82,7 +102,7 @@ def test_lwz_exposes_compressor_frequency() -> None:
 
 
 def test_wpm_exposes_power_consumption_statistics() -> None:
-    """WPM power-consumption windows read the 3707-3723 energy_data fields.
+    """WPM power-consumption windows read the 3707-3723 extended_energy_data fields.
 
     Each window is a register pair that the library sums as
     ``low + high * 1000``, which yields the smaller of the two units the


### PR DESCRIPTION
## What

Two small things left over after 1864cae, which already did the 0.6.2 bump and moved the power-consumption windows.

## 1. The WPM 3i HK1 setpoint, #602

The 3i takes `SET TEMPERATURE HK 1` from wire address 508, register 509 in the manual, which is the column the manual marks as the WPM 3i variant. A real WPM 3i leaves that at `0x8000` and answers on wire 509, manual 510, the address the WPM models use. So the entity is unavailable on a 3i.

0.6.2 carries both fields, so this only changes which one the entity reads. The entity key is untouched, so `entity_id`, unique id and recorded history carry over.

Measured on two installations, and the two measurements cover different halves of it.

A WPM 3i, read against its Servicewelt. The neighbouring registers matter as much as the setpoint, because they are what rules out an off-by-one in the block:

| wire | manual | field | read | Servicewelt |
|---|---|---|---|---|
| 506 | 507 | `outside_temperature` | 192 | AUSSENTEMPERATUR 19.2 °C |
| 507 | 508 | `actual_temperature_hk_1` | 172 | ISTTEMPERATUR HK 1 17.2 °C |
| 508 | 509 | `set_temperature_hk_1_wpm3i` | 0x8000 | not shown |
| 509 | 510 | `set_temperature_hk_1` | 50 | SOLLTEMPERATUR HK 1 5.0 °C |

The WPC 05 in #602. Th1234567 changed the setpoint and watched which register followed:

| | Servicewelt | wire 509 | wire 510 |
|---|---|---|---|
| before | 5.0 °C | 50 | -32768 |
| after | 16.2 °C | 162 | -32768 |

A matching value alone would be weak evidence: 5.0 °C is what an idle WPM 3i shows in summer, so both machines sitting at it says little. The change is what identifies the register, and wire 508 reading `0x8000` is what explains the unavailable entity.

Those are addresses as pymodbus takes them, one below the manual. Worth stating, because the same digits mean different registers in that thread.

This is the integration side of ThyMYthOS/python-stiebel-eltron#63, which added `set_temperature_hk_1` to the 3i model and kept `set_temperature_hk_1_wpm3i`, so nothing disappears for a machine that does behave as documented.

## 2. The API mock has no `extended_energy_data`

The optional components are built in the API constructor, so the `autospec` mock does not know them, and every accessor on `extended_energy_data` raises `AttributeError`. On current `main` the nine power-consumption windows reach the entity registry but fail while being added, so they never get a state, and nothing in the suite notices.

`test_setup_registers_every_wpm_sensor` asserts that every WPM sensor ends up with a state. It fails on those nine without the fixture entry, so the next optional component cannot drop its entities quietly either.

## Checks

532 passed, 4 skipped. `ruff check` and `ruff format --check` clean, `mypy` clean for `custom_components`. Two commits, rebased on current `main`.

## Summary by Sourcery

Adjust WPM 3i HK1 target temperature sensor to read the shared setpoint field and ensure all WPM sensors, including power-consumption windows, obtain states in tests.

New Features:
- Add a test verifying the WPM 3i HK1 target temperature sensor reads the shared set_temperature_hk_1 field instead of the WPM3i-specific register.

Enhancements:
- Update the WPM HK1 target temperature sensor definition to use the shared set_temperature_hk_1 value for compatibility with real WPM 3i installations.
- Extend the WPM API mock to include the optional extended_energy_data component so its entities are created correctly.

Tests:
- Add a Home Assistant test that asserts every WPM sensor description results in a registered entity with a state, preventing silent loss of optional-component sensors.
- Adjust sensor tests to validate the WPM 3i HK1 target temperature mapping and clarify that power-consumption windows read from extended_energy_data.