### PR TITLE
Expose the inverter power reading on WPMsystem

### DIFF
--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfEnergy,
     UnitOfFrequency,
+    UnitOfPower,
     UnitOfPressure,
     UnitOfTemperature,
     UnitOfVolumeFlowRate,
@@ -64,6 +65,7 @@ from .const import (
     CONSUMED_WATER_HEATING_TODAY,
     CONSUMED_WATER_HEATING_TOTAL,
     COOLING_RUNTIME,
+    CURRENT_POWER_CONSUMPTION,
     DEWPOINT_TEMPERATURE,
     DEWPOINT_TEMPERATURE_HK1,
     DEWPOINT_TEMPERATURE_HK2,
@@ -1111,6 +1113,27 @@ WPM_POWER_CONSUMPTION_SENSOR_TYPES = [
     ),
 ]
 
+# Servicewelt "PROZESSDATEN" -> INVERTER AUFNAHMELEISTUNG, wire register 3679.
+# Verified against a WPMsystem while its compressor modulated: raw 6, 10 and 11
+# read 0.6, 1.0 and 1.1 kW on the ISG display in the same sample, which fixes
+# the library's 0.1 scale. The LWZ side declares 0.01 on the same wire address
+# and is deliberately left out until someone measures it.
+#
+# Only IWS 1 is exposed. The library carries inverter_power_iws_2 through _6 for
+# cascades; on a single-compressor machine those read the unavailable marker, so
+# exposing all six would give most installations five dead entities.
+WPM_INVERTER_POWER_SENSOR_TYPES = [
+    StiebelEltronSensorEntityDescription(
+        key=CURRENT_POWER_CONSUMPTION,
+        translation_key=CURRENT_POWER_CONSUMPTION,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        icon="mdi:flash",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        modbus_register=lambda api: api.extended_energy_data.inverter_power_iws_1,
+    ),
+]
+
 
 WPM_3I_SENSOR_TYPES = (
     WPM_3I_SYSTEM_VALUES_SENSOR_TYPES
@@ -1184,6 +1207,15 @@ async def async_setup_entry(
             for description in ENERGY_DAILY_SENSOR_TYPES
         ]
         entities.extend(daily_energy_entities)
+        if coordinator.model == ControllerModel.WPMsystem:
+            # Only WPMsystem is measured to answer wire 3679. A WPM 3i refuses
+            # it outright, and nothing is known about WPM_3 or LWZ_R290, so the
+            # sensor stays off the shared list rather than risk an entity that
+            # can never hold a value.
+            entities.extend(
+                StiebelEltronISGSensor(coordinator, entry, description)
+                for description in WPM_INVERTER_POWER_SENSOR_TYPES
+            )
     else:
         entities = [
             StiebelEltronISGSensor(

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -347,6 +347,9 @@
             "cooling_runtime": {
                 "name": "Cooling Runtime"
             },
+            "current_power_consumption": {
+                "name": "Inverter Power Consumption"
+            },
             "electrical_booster_heating": {
                 "name": "Electrical Booster Heating"
             },

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -347,6 +347,9 @@
             "cooling_runtime": {
                 "name": "Kühlbetrieb Laufzeit"
             },
+            "current_power_consumption": {
+                "name": "Inverter Aufnahmeleistung"
+            },
             "electrical_booster_heating": {
                 "name": "Elektroheizung Heizung"
             },

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -336,6 +336,9 @@
             "cooling_runtime": {
                 "name": "Cooling Runtime"
             },
+            "current_power_consumption": {
+                "name": "Inverter Power Consumption"
+            },
             "electrical_booster_heating": {
                 "name": "Electrical Booster Heating"
             },

--- a/tests/entity_keys.txt
+++ b/tests/entity_keys.txt
@@ -56,6 +56,7 @@ consumed_water_heating_today
 consumed_water_heating_total
 cooling_mode
 cooling_runtime
+current_power_consumption
 dew_point_temperature
 dew_point_temperature_hk1
 dew_point_temperature_hk2

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -72,6 +72,8 @@ _DESCRIPTION_LISTS: list[tuple[str, str, list[Any]]] = [
     ("NUMBER_TYPES_WPM_3I", WPM_3I, number.NUMBER_TYPES_WPM_3I),
     ("NUMBER_TYPES_LWZ", LWZ, number.NUMBER_TYPES_LWZ),
     ("WPM_SENSOR_TYPES", WPM, sensor.WPM_SENSOR_TYPES),
+    # WPMsystem only, see the comment on the list itself.
+    ("WPM_INVERTER_POWER_SENSOR_TYPES", WPM, sensor.WPM_INVERTER_POWER_SENSOR_TYPES),
     ("WPM_3I_SENSOR_TYPES", WPM_3I, sensor.WPM_3I_SENSOR_TYPES),
     ("LWZ_SENSOR_TYPES", LWZ, sensor.LWZ_SENSOR_TYPES),
     ("ENERGY_DAILY_SENSOR_TYPES", WPM, sensor.ENERGY_DAILY_SENSOR_TYPES),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -69,6 +69,10 @@ async def test_setup_registers_every_wpm_sensor(
     ("model", "expected"),
     [
         (ControllerModel.WPMsystem, True),
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        (ControllerModel.WPMsystem, True),
         (ControllerModel.WPM_3, False),
         (ControllerModel.LWZ_R290, False),
     ],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -67,7 +67,11 @@ async def test_setup_registers_every_wpm_sensor(
 
 @pytest.mark.parametrize(
     ("model", "expected"),
-    [(ControllerModel.WPMsystem, True), (ControllerModel.WPM_3, False)],
+    [
+        (ControllerModel.WPMsystem, True),
+        (ControllerModel.WPM_3, False),
+        (ControllerModel.LWZ_R290, False),
+    ],
 )
 async def test_inverter_power_is_created_for_wpmsystem_only(
     hass: HomeAssistant,
@@ -80,6 +84,8 @@ async def test_inverter_power_is_created_for_wpmsystem_only(
 
     WPM_3, WPMsystem and LWZ_R290 share one sensor list, so without a model
     check the other two would be handed an entity that can never hold a value.
+    All three are covered here so that a change to ``async_setup_entry`` cannot
+    quietly widen the set again.
     """
     mock_get_controller_model.return_value = model
     mock_config_entry.add_to_hass(hass)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,11 +8,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from modbus_connection import ModbusError, ModbusTimeoutError
 from modbus_connection.mock import MockModbusConnection
-from pystiebeleltron import StiebelEltronModbusError, UnknownControllerModelError
+from pystiebeleltron import (
+    ControllerModel,
+    StiebelEltronModbusError,
+    UnknownControllerModelError,
+)
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.stiebel_eltron_isg.const import DOMAIN
+from custom_components.stiebel_eltron_isg.const import CURRENT_POWER_CONSUMPTION, DOMAIN
 from custom_components.stiebel_eltron_isg.entity import build_unique_id
 from custom_components.stiebel_eltron_isg.sensor import WPM_SENSOR_TYPES
 
@@ -59,6 +63,40 @@ async def test_setup_registers_every_wpm_sensor(
             stateless.append(description.key)
 
     assert not stateless, f"These sensors never got a state: {sorted(stateless)}"
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [(ControllerModel.WPMsystem, True), (ControllerModel.WPM_3, False)],
+)
+async def test_inverter_power_is_created_for_wpmsystem_only(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_get_controller_model: MagicMock,
+    model: ControllerModel,
+    expected: bool,
+) -> None:
+    """Wire 3679 is only confirmed answered on WPMsystem.
+
+    WPM_3, WPMsystem and LWZ_R290 share one sensor list, so without a model
+    check the other two would be handed an entity that can never hold a value.
+    """
+    mock_get_controller_model.return_value = model
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    unique_ids = {
+        entry.unique_id
+        for entry in er.async_entries_for_config_entry(
+            er.async_get(hass), mock_config_entry.entry_id
+        )
+    }
+    created = (
+        build_unique_id(mock_config_entry, CURRENT_POWER_CONSUMPTION) in unique_ids
+    )
+    assert created is expected
 
 
 async def test_async_setup_entry_with_custom_port(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,7 +3,7 @@
 from types import SimpleNamespace
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import UnitOfEnergy, UnitOfFrequency
+from homeassistant.const import UnitOfEnergy, UnitOfFrequency, UnitOfPower
 import pytest
 
 from custom_components.stiebel_eltron_isg.const import (
@@ -20,6 +20,7 @@ from custom_components.stiebel_eltron_isg.const import (
     CONSUMED_WATER_HEATING_LAST_24H,
     CONSUMED_WATER_HEATING_PREV_12M,
     COOLING_RUNTIME,
+    CURRENT_POWER_CONSUMPTION,
     PRODUCED_ELECTRICAL_BOOSTER_HEATING_TOTAL,
     PRODUCED_ELECTRICAL_BOOSTER_WATER_HEATING_TOTAL,
     PRODUCED_SOLAR_HEATING,
@@ -31,6 +32,7 @@ from custom_components.stiebel_eltron_isg.const import (
 from custom_components.stiebel_eltron_isg.sensor import (
     LWZ_SENSOR_TYPES,
     WPM_3I_SENSOR_TYPES,
+    WPM_INVERTER_POWER_SENSOR_TYPES,
     WPM_SENSOR_TYPES,
 )
 
@@ -200,3 +202,42 @@ def test_lwz_solar_sensors_are_not_duplicates() -> None:
     assert values == expected
     # A duplicated accessor would collapse two of the four sensors.
     assert len(set(values.values())) == 4
+
+
+def test_inverter_power_reads_the_measured_field() -> None:
+    """Inverter power reads extended_energy_data.inverter_power_iws_1 (3679).
+
+    The scale was measured on a WPMsystem while its compressor modulated: raw
+    values of 6, 10 and 11 stood next to 0.6, 1.0 and 1.1 kW on the ISG display
+    in the same sample, which is where the library's 0.1 factor comes from. The
+    value below is one of those readings after the library applies the scale.
+
+    Only IWS 1 is exposed. The library carries inverter_power_iws_2 through _6
+    for cascades, and on a single-compressor machine those read the unavailable
+    marker, so exposing all six would leave most installations with five dead
+    entities.
+    """
+    api = SimpleNamespace(
+        extended_energy_data=SimpleNamespace(inverter_power_iws_1=1.1)
+    )
+
+    desc = next(
+        d for d in WPM_INVERTER_POWER_SENSOR_TYPES if d.key == CURRENT_POWER_CONSUMPTION
+    )
+    assert desc.modbus_register(api) == 1.1
+    assert desc.native_unit_of_measurement == UnitOfPower.KILO_WATT
+    assert desc.device_class == SensorDeviceClass.POWER
+    # An instantaneous reading, not a counter.
+    assert desc.state_class == SensorStateClass.MEASUREMENT
+
+
+def test_inverter_power_stays_out_of_the_shared_lists() -> None:
+    """It must not ride along on models where the register is not measured.
+
+    ``WPM_SENSOR_TYPES`` serves WPM_3, WPMsystem and LWZ_R290 alike, but wire
+    3679 is only confirmed answered on WPMsystem, and a WPM 3i refuses it with
+    Modbus exception 2. Adding it to the shared list would hand the other models
+    an entity that can never hold a value.
+    """
+    for sensor_types in (WPM_SENSOR_TYPES, WPM_3I_SENSOR_TYPES, LWZ_SENSOR_TYPES):
+        assert not [d for d in sensor_types if d.key == CURRENT_POWER_CONSUMPTION]


### PR DESCRIPTION
Closes #608.

`const.py` has carried `CURRENT_POWER_CONSUMPTION` without an entity behind it, and the library has carried `inverter_power_iws_1` on wire register 3679 without anything reading it. #608 asks for exactly that value; the reporter currently pulls it in with a second Modbus integration running alongside this one.

### The scale was the open question

`wpm.py` declares `gauge(3679, 0.1, unit="kW")` and `lwz.py` declares `0.01` on the same wire address, so the factor could not be taken on faith. Measured on a WPMsystem while its compressor modulated, with the ISG web display read in the same sample:

```
raw  6   ->  0,6 kW      compressor at 25 Hz
raw 10   ->  1,0 kW      compressor at 40 Hz
raw 11   ->  1,1 kW      compressor at 40 Hz
```

That fixes the WPM side at `0.1`. LWZ is deliberately untouched here; its differing factor would need its own measurement.

### Why it is attached to WPMsystem alone

`WPM_SENSOR_TYPES` also serves `WPM_3` and `LWZ_R290`. Wire 3679 is only confirmed answered on WPMsystem, and a WPM 3i refuses it with Modbus exception 2. Putting the description on the shared list would hand the other models an entity that can never hold a value, which is the failure mode described in #612. It is therefore appended in `async_setup_entry` under a model check, and a parametrised test covers both directions.

If someone running a WPM_3 or an LWZ_R290 posts a reading, extending it is a one-line change.

### Only IWS 1

The library carries `inverter_power_iws_2` through `_6` for cascades. On a single-compressor machine those read the unavailable marker, so exposing all six would leave most installations with five dead entities. They can follow once someone with a cascade can verify them.

### Verification

- 537 passed, 4 skipped
- `ruff check` and `ruff format --check` clean
- The five `mypy` errors in `__init__.py` are pre-existing; checked against the unchanged tree and identical there. `sensor.py` itself is clean.
- Measured read-only against real hardware, as described above

One open point from the issue thread: I have asked the reporter whether a single sensor for the heat pump's inverter input power is what he was after, or whether he expected something per compressor. If the answer changes the shape, this can wait.

## Summary by Sourcery

Expose the inverter power reading as a dedicated sensor for WPMsystem controllers while keeping other models unaffected.

New Features:
- Add a CURRENT_POWER_CONSUMPTION sensor mapped to the inverter_power_iws_1 field for WPMsystem controllers, reporting instantaneous inverter input power in kW.

Tests:
- Add tests verifying the inverter power sensor reads the correct scaled value, is only created for WPMsystem models, remains absent from shared sensor lists, and is included in entity description coverage.