### PR TITLE
Give eight entities back the names their keys never found

### DIFF
--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -74,16 +74,16 @@
             "actual_humidity_hk3": {
                 "name": "Humidity HK 3"
             },
-            "dewpoint_temperature": {
+            "dew_point_temperature": {
                 "name": "Dew Point Temperature"
             },
-            "dewpoint_temperature_hk1": {
+            "dew_point_temperature_hk1": {
                 "name": "Dew Point Temperature HK 1"
             },
-            "dewpoint_temperature_hk2": {
+            "dew_point_temperature_hk2": {
                 "name": "Dew Point Temperature HK 2"
             },
-            "dewpoint_temperature_hk3": {
+            "dew_point_temperature_hk3": {
                 "name": "Dew Point Temperature HK 3"
             },
             "outdoor_temperature": {
@@ -362,10 +362,10 @@
             "ventilation_air_target_flow_rate": {
                 "name": "Ventilation Air Target Flow Rate"
             },
-            "extract_air_actual_fan_speed": {
+            "extract_air_actual": {
                 "name": "Extract Air Actual Fan Speed"
             },
-            "extract_air_target_flow_rate": {
+            "extract_air_target_flowrate": {
                 "name": "Extract Air Target Flow Rate"
             },
             "extract_air_dew_point": {
@@ -606,10 +606,10 @@
             "heating_curve_rise_hk3": {
                 "name": "Heating Curve Rise HK3"
             },
-            "fan_level_day": {
+            "fan_level_comfort": {
                 "name": "Fan Level Day"
             },
-            "fan_level_night": {
+            "fan_level_eco": {
                 "name": "Fan Level Night"
             },
             "fan_level_party": {

--- a/custom_components/stiebel_eltron_isg/translations/cz.json
+++ b/custom_components/stiebel_eltron_isg/translations/cz.json
@@ -74,16 +74,16 @@
             "actual_humidity_hk3": {
                 "name": "Vlhkost vzduchu TO 3"
             },
-            "dewpoint_temperature": {
+            "dew_point_temperature": {
                 "name": "Teplota rosného bodu"
             },
-            "dewpoint_temperature_hk1": {
+            "dew_point_temperature_hk1": {
                 "name": "Teplota rosného bodu TO 1"
             },
-            "dewpoint_temperature_hk2": {
+            "dew_point_temperature_hk2": {
                 "name": "Teplota rosného bodu TO 2"
             },
-            "dewpoint_temperature_hk3": {
+            "dew_point_temperature_hk3": {
                 "name": "Teplota rosného bodu TO 3"
             },
             "outdoor_temperature": {
@@ -329,10 +329,10 @@
             "ventilation_air_target_flow_rate": {
                 "name": "Přiváděný vzduch požadovaný průtok"
             },
-            "extract_air_actual_fan_speed": {
+            "extract_air_actual": {
                 "name": "Odváděný vzduch skutečné otáčky"
             },
-            "extract_air_target_flow_rate": {
+            "extract_air_target_flowrate": {
                 "name": "Odváděný vzduch požadovaný průtok"
             },
             "extract_air_dew_point": {
@@ -567,10 +567,10 @@
             "heating_curve_rise_hk3": {
                 "name": "Sklon topné křivky TO 3"
             },
-            "fan_level_day": {
+            "fan_level_comfort": {
                 "name": "Stupeň ventilátoru den"
             },
-            "fan_level_night": {
+            "fan_level_eco": {
                 "name": "Stupeň ventilátoru noc"
             },
             "comfort_cooling_temperature_target_hk1": {

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -74,16 +74,16 @@
             "actual_humidity_hk3": {
                 "name": "Luftfeuchtigkeit HK 3"
             },
-            "dewpoint_temperature": {
+            "dew_point_temperature": {
                 "name": "Taupunkttemperatur"
             },
-            "dewpoint_temperature_hk1": {
+            "dew_point_temperature_hk1": {
                 "name": "Taupunkttemperatur HK 1"
             },
-            "dewpoint_temperature_hk2": {
+            "dew_point_temperature_hk2": {
                 "name": "Taupunkttemperatur HK 2"
             },
-            "dewpoint_temperature_hk3": {
+            "dew_point_temperature_hk3": {
                 "name": "Taupunkttemperatur HK 3"
             },
             "outdoor_temperature": {
@@ -362,10 +362,10 @@
             "ventilation_air_target_flow_rate": {
                 "name": "Zuluft Soll-Volumenstrom"
             },
-            "extract_air_actual_fan_speed": {
+            "extract_air_actual": {
                 "name": "Abluft Ist-Lüfterdrehzahl"
             },
-            "extract_air_target_flow_rate": {
+            "extract_air_target_flowrate": {
                 "name": "Abluft Soll-Volumenstrom"
             },
             "extract_air_dew_point": {
@@ -606,10 +606,10 @@
             "heating_curve_rise_hk3": {
                 "name": "Heizkurve Steilheit HK 3"
             },
-            "fan_level_day": {
+            "fan_level_comfort": {
                 "name": "Lüfterstufe Tag"
             },
-            "fan_level_night": {
+            "fan_level_eco": {
                 "name": "Lüfterstufe Nacht"
             },
             "fan_level_party": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -63,16 +63,16 @@
             "actual_humidity_hk3": {
                 "name": "Humidity HK 3"
             },
-            "dewpoint_temperature": {
+            "dew_point_temperature": {
                 "name": "Dew Point Temperature"
             },
-            "dewpoint_temperature_hk1": {
+            "dew_point_temperature_hk1": {
                 "name": "Dew Point Temperature HK 1"
             },
-            "dewpoint_temperature_hk2": {
+            "dew_point_temperature_hk2": {
                 "name": "Dew Point Temperature HK 2"
             },
-            "dewpoint_temperature_hk3": {
+            "dew_point_temperature_hk3": {
                 "name": "Dew Point Temperature HK 3"
             },
             "outdoor_temperature": {
@@ -351,10 +351,10 @@
             "ventilation_air_target_flow_rate": {
                 "name": "Ventilation Air Target Flow Rate"
             },
-            "extract_air_actual_fan_speed": {
+            "extract_air_actual": {
                 "name": "Extract Air Actual Fan Speed"
             },
-            "extract_air_target_flow_rate": {
+            "extract_air_target_flowrate": {
                 "name": "Extract Air Target Flow Rate"
             },
             "extract_air_dew_point": {
@@ -595,10 +595,10 @@
             "heating_curve_rise_hk3": {
                 "name": "Heating Curve Rise HK3"
             },
-            "fan_level_day": {
+            "fan_level_comfort": {
                 "name": "Fan Level Day"
             },
-            "fan_level_night": {
+            "fan_level_eco": {
                 "name": "Fan Level Night"
             },
             "fan_level_party": {

--- a/custom_components/stiebel_eltron_isg/translations/fr.json
+++ b/custom_components/stiebel_eltron_isg/translations/fr.json
@@ -74,16 +74,16 @@
             "actual_humidity_hk3": {
                 "name": "Humidité CC 3"
             },
-            "dewpoint_temperature": {
+            "dew_point_temperature": {
                 "name": "Température de rosée"
             },
-            "dewpoint_temperature_hk1": {
+            "dew_point_temperature_hk1": {
                 "name": "Température de rosée CC 1"
             },
-            "dewpoint_temperature_hk2": {
+            "dew_point_temperature_hk2": {
                 "name": "Température de rosée CC 2"
             },
-            "dewpoint_temperature_hk3": {
+            "dew_point_temperature_hk3": {
                 "name": "Température de rosée CC 3"
             },
             "outdoor_temperature": {
@@ -329,10 +329,10 @@
             "ventilation_air_target_flow_rate": {
                 "name": "Débit cible air soufflage"
             },
-            "extract_air_actual_fan_speed": {
+            "extract_air_actual": {
                 "name": "Vitesse réelle ventilateur extraction"
             },
-            "extract_air_target_flow_rate": {
+            "extract_air_target_flowrate": {
                 "name": "Débit cible air extraction"
             },
             "extract_air_dew_point": {
@@ -567,10 +567,10 @@
             "heating_curve_rise_hk3": {
                 "name": "Pente courbe de chauffe CC 3"
             },
-            "fan_level_day": {
+            "fan_level_comfort": {
                 "name": "Niveau ventilateur jour"
             },
-            "fan_level_night": {
+            "fan_level_eco": {
                 "name": "Niveau ventilateur nuit"
             },
             "comfort_cooling_temperature_target_hk1": {

--- a/custom_components/stiebel_eltron_isg/translations/it.json
+++ b/custom_components/stiebel_eltron_isg/translations/it.json
@@ -74,16 +74,16 @@
             "actual_humidity_hk3": {
                 "name": "Umidità CC 3"
             },
-            "dewpoint_temperature": {
+            "dew_point_temperature": {
                 "name": "Temperatura punto di rugiada"
             },
-            "dewpoint_temperature_hk1": {
+            "dew_point_temperature_hk1": {
                 "name": "Temperatura punto di rugiada CC 1"
             },
-            "dewpoint_temperature_hk2": {
+            "dew_point_temperature_hk2": {
                 "name": "Temperatura punto di rugiada CC 2"
             },
-            "dewpoint_temperature_hk3": {
+            "dew_point_temperature_hk3": {
                 "name": "Temperatura punto di rugiada CC 3"
             },
             "outdoor_temperature": {
@@ -329,10 +329,10 @@
             "ventilation_air_target_flow_rate": {
                 "name": "Portata target aria immessa"
             },
-            "extract_air_actual_fan_speed": {
+            "extract_air_actual": {
                 "name": "Velocità effettiva ventilatore aria estratta"
             },
-            "extract_air_target_flow_rate": {
+            "extract_air_target_flowrate": {
                 "name": "Portata target aria estratta"
             },
             "extract_air_dew_point": {
@@ -567,10 +567,10 @@
             "heating_curve_rise_hk3": {
                 "name": "Pendenza curva climatica CC 3"
             },
-            "fan_level_day": {
+            "fan_level_comfort": {
                 "name": "Livello ventilatore giorno"
             },
-            "fan_level_night": {
+            "fan_level_eco": {
                 "name": "Livello ventilatore notte"
             },
             "comfort_cooling_temperature_target_hk1": {

--- a/custom_components/stiebel_eltron_isg/translations/pt.json
+++ b/custom_components/stiebel_eltron_isg/translations/pt.json
@@ -74,16 +74,16 @@
             "actual_humidity_hk3": {
                 "name": "Humidade CC 3"
             },
-            "dewpoint_temperature": {
+            "dew_point_temperature": {
                 "name": "Temperatura de ponto de orvalho"
             },
-            "dewpoint_temperature_hk1": {
+            "dew_point_temperature_hk1": {
                 "name": "Temperatura ponto de orvalho CC 1"
             },
-            "dewpoint_temperature_hk2": {
+            "dew_point_temperature_hk2": {
                 "name": "Temperatura ponto de orvalho CC 2"
             },
-            "dewpoint_temperature_hk3": {
+            "dew_point_temperature_hk3": {
                 "name": "Temperatura ponto de orvalho CC 3"
             },
             "outdoor_temperature": {
@@ -329,10 +329,10 @@
             "ventilation_air_target_flow_rate": {
                 "name": "Caudal alvo ar de insuflação"
             },
-            "extract_air_actual_fan_speed": {
+            "extract_air_actual": {
                 "name": "Velocidade real ventilador ar de extracção"
             },
-            "extract_air_target_flow_rate": {
+            "extract_air_target_flowrate": {
                 "name": "Caudal alvo ar de extracção"
             },
             "extract_air_dew_point": {
@@ -567,10 +567,10 @@
             "heating_curve_rise_hk3": {
                 "name": "Inclinação curva de aquecimento CC 3"
             },
-            "fan_level_day": {
+            "fan_level_comfort": {
                 "name": "Nível ventilador dia"
             },
-            "fan_level_night": {
+            "fan_level_eco": {
                 "name": "Nível ventilador noite"
             },
             "comfort_cooling_temperature_target_hk1": {

--- a/custom_components/stiebel_eltron_isg/translations/sk.json
+++ b/custom_components/stiebel_eltron_isg/translations/sk.json
@@ -74,16 +74,16 @@
             "actual_humidity_hk3": {
                 "name": "Vlhkosť vzduchu TO 3"
             },
-            "dewpoint_temperature": {
+            "dew_point_temperature": {
                 "name": "Teplota rosného bodu"
             },
-            "dewpoint_temperature_hk1": {
+            "dew_point_temperature_hk1": {
                 "name": "Teplota rosného bodu TO 1"
             },
-            "dewpoint_temperature_hk2": {
+            "dew_point_temperature_hk2": {
                 "name": "Teplota rosného bodu TO 2"
             },
-            "dewpoint_temperature_hk3": {
+            "dew_point_temperature_hk3": {
                 "name": "Teplota rosného bodu TO 3"
             },
             "outdoor_temperature": {
@@ -329,10 +329,10 @@
             "ventilation_air_target_flow_rate": {
                 "name": "Privádzaný vzduch požadovaný prietok"
             },
-            "extract_air_actual_fan_speed": {
+            "extract_air_actual": {
                 "name": "Odvádzaný vzduch skutočné otáčky"
             },
-            "extract_air_target_flow_rate": {
+            "extract_air_target_flowrate": {
                 "name": "Odvádzaný vzduch požadovaný prietok"
             },
             "extract_air_dew_point": {
@@ -567,10 +567,10 @@
             "heating_curve_rise_hk3": {
                 "name": "Sklon vykurovacej krivky TO 3"
             },
-            "fan_level_day": {
+            "fan_level_comfort": {
                 "name": "Stupeň ventilátora deň"
             },
-            "fan_level_night": {
+            "fan_level_eco": {
                 "name": "Stupeň ventilátora noc"
             },
             "comfort_cooling_temperature_target_hk1": {

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,170 @@
+"""Guards that every entity description actually resolves to a name.
+
+An entity description names its entity through ``translation_key``, which is
+looked up under ``entity.<platform>.<translation_key>`` in the translation
+files. A key with no entry there does not fail: Home Assistant gives the entity
+no name at all, falls back to the device name for its entity id, and appends
+``_2`` to the second one that collides. That is what #614 reported, and it had
+been shipping since translation keys were introduced, because the keys the code
+passes and the keys the files carry drifted apart for eight entities while both
+sides looked reasonable on their own.
+
+The check is deliberately made against imported description objects rather than
+by scanning the source: four of those eight came out of
+``sensor.create_temperature_entity_description``, so a search for literal
+``translation_key=`` arguments finds only half of them. Anything a factory
+builds at import time is an ordinary object in a module level list, which
+introspection sees and a text search does not.
+
+``translations/en.json`` is what the running integration reads, so it is the
+file that decides whether an entity has a name. ``strings.json`` is the source
+the translation files are maintained from, and a key present in one but not the
+other means one of them is stale, so both directions are compared as well.
+"""
+
+import json
+import pathlib
+from types import ModuleType
+
+from homeassistant.helpers.entity import EntityDescription
+import pytest
+
+from custom_components.stiebel_eltron_isg import (
+    binary_sensor,
+    button,
+    climate,
+    number,
+    select,
+    sensor,
+    switch,
+)
+
+_PLATFORM_MODULES = (binary_sensor, button, climate, number, select, sensor, switch)
+
+_COMPONENT_DIR = (
+    pathlib.Path(__file__).parent.parent / "custom_components" / "stiebel_eltron_isg"
+)
+_STRINGS_FILE = _COMPONENT_DIR / "strings.json"
+_TRANSLATIONS_DIR = _COMPONENT_DIR / "translations"
+_RUNTIME_FILE = _TRANSLATIONS_DIR / "en.json"
+
+
+def _platform(module: ModuleType) -> str:
+    """Return the platform domain a module provides entities for."""
+    return module.__name__.rsplit(".", 1)[-1]
+
+
+def _descriptions(module: ModuleType) -> list[EntityDescription]:
+    """Return every entity description a module holds in a module level list."""
+    return [
+        description
+        for value in vars(module).values()
+        if isinstance(value, (list, tuple))
+        and value
+        and all(isinstance(item, EntityDescription) for item in value)
+        for description in value
+    ]
+
+
+def _entity_names(file: pathlib.Path) -> dict[str, dict[str, dict]]:
+    """Return the ``entity`` section of a translation file."""
+    return json.loads(file.read_text(encoding="utf-8")).get("entity", {})
+
+
+def _translation_keys(file: pathlib.Path, platform: str) -> set[str]:
+    """Return the keys a translation file carries for one platform."""
+    return set(_entity_names(file).get(platform, {}))
+
+
+@pytest.mark.parametrize("module", _PLATFORM_MODULES, ids=_platform)
+def test_every_translation_key_has_a_name(module: ModuleType) -> None:
+    """A description whose key does not resolve leaves its entity unnamed."""
+    names = _entity_names(_RUNTIME_FILE).get(_platform(module), {})
+
+    unnamed = {
+        f"{description.key} -> {description.translation_key}"
+        for description in _descriptions(module)
+        if description.translation_key is not None
+        and not names.get(description.translation_key, {}).get("name")
+    }
+
+    assert not unnamed, (
+        f"{_platform(module)} descriptions without a name in "
+        f"{_RUNTIME_FILE.name}: {sorted(unnamed)}"
+    )
+
+
+@pytest.mark.parametrize("module", _PLATFORM_MODULES, ids=_platform)
+def test_no_translation_is_orphaned(module: ModuleType) -> None:
+    """A name no description asks for is the other half of the same drift.
+
+    Both sides of #614 were present at once: eight entities without a name, and
+    the eight names they were meant to use sitting unused beside them. Catching
+    only the first direction would have left the second to be found by hand.
+    """
+    used = {
+        description.translation_key
+        for description in _descriptions(module)
+        if description.translation_key is not None
+    }
+
+    orphaned = _translation_keys(_RUNTIME_FILE, _platform(module)) - used
+
+    assert not orphaned, (
+        f"{_platform(module)} names in {_RUNTIME_FILE.name} no description uses: "
+        f"{sorted(orphaned)}"
+    )
+
+
+def test_english_matches_strings() -> None:
+    """English carries exactly the keys the source file declares.
+
+    Only ``translations/`` is read at runtime, and English is what every other
+    language falls back to, so these two files have to agree in both
+    directions: a key that reaches ``strings.json`` alone never names anything,
+    and one that reaches ``en.json`` alone is never asked for.
+    """
+    strings = _entity_names(_STRINGS_FILE)
+    english = _entity_names(_RUNTIME_FILE)
+
+    differences = {
+        platform: {
+            "missing": sorted(set(keys) - set(english.get(platform, {}))),
+            "extra": sorted(set(english.get(platform, {})) - set(keys)),
+        }
+        for platform, keys in strings.items()
+        if set(keys) != set(english.get(platform, {}))
+    }
+
+    assert not differences, (
+        f"{_RUNTIME_FILE.name} entity keys differ from "
+        f"{_STRINGS_FILE.name}: {differences}"
+    )
+
+
+@pytest.mark.parametrize(
+    "translation_file",
+    sorted(file for file in _TRANSLATIONS_DIR.glob("*.json") if file != _RUNTIME_FILE),
+    ids=lambda file: file.stem,
+)
+def test_translation_invents_no_key(translation_file: pathlib.Path) -> None:
+    """A language may lag behind, but may not carry keys nothing declares.
+
+    Home Assistant falls back to English per key, so a language that is missing
+    recent entries still names its entities, and several of these files are
+    incomplete on purpose. A key English does not have is the other case: it
+    names nothing and marks a rename that was only carried halfway.
+    """
+    english = _entity_names(_RUNTIME_FILE)
+    translated = _entity_names(translation_file)
+
+    unknown = {
+        platform: sorted(set(keys) - set(english.get(platform, {})))
+        for platform, keys in translated.items()
+        if set(keys) - set(english.get(platform, {}))
+    }
+
+    assert not unknown, (
+        f"{translation_file.name} has entity keys {_RUNTIME_FILE.name} "
+        f"does not: {unknown}"
+    )


### PR DESCRIPTION
Reported in #614: two ventilation settings arrive as
number.<device_name> and number.<device_name>_2, with no name of their own.
Six more entities have the same defect and were not reported.

An entity is named through the translation file, under
entity.<platform>.<translation_key>. A key with no entry there does not raise:
the entity gets no name, Home Assistant falls back to the device name to build
an entity id, and the second one that collides gets _2. For each of the eight,
the name it was meant to use is present in every translation file, sitting
unused under a slightly different key:

    number  fan_level_comfort           <-  fan_level_day
    number  fan_level_eco               <-  fan_level_night
    sensor  extract_air_actual          <-  extract_air_actual_fan_speed
    sensor  extract_air_target_flowrate <-  extract_air_target_flow_rate
    sensor  dew_point_temperature       <-  dewpoint_temperature
    sensor  dew_point_temperature_hk1   <-  dewpoint_temperature_hk1
    sensor  dew_point_temperature_hk2   <-  dewpoint_temperature_hk2
    sensor  dew_point_temperature_hk3   <-  dewpoint_temperature_hk3

The drift dates from cebecb0, which replaced hard coded name= arguments with
translation keys. The names moved into the files under readable slugs while the
code kept passing the constants it had used since 8e6c367 in 2023. Where the
two happened to agree the entity kept its name, and these eight are where they
did not.

Renaming the key in the files rather than the constant in the code, because the
constant is also the description key, and the description key is the unique id.
Changing it would orphan every one of these entities along with its history and
long term statistics. That constraint also rules out the reverse fix of
pointing translation_key at the file: four of the eight are built by
sensor.create_temperature_entity_description, which derives translation_key
from key, so it would need a second parameter threaded through the factory to
express what a rename in a JSON file says on its own. fan_level_comfort is a
poor name for a day setting, but it is the name already frozen into every
existing unique id, and a translation key is never shown to anyone.

All eight files carry the same eight keys, so all eight are renamed: only
translations/ is read at runtime, and strings.json is the source they are
maintained from. Values are untouched, and each file changes on exactly eight
lines.

The guard test that comes with it inspects imported description objects rather
than the source text. Four of these eight came out of a factory, so a search
for literal translation_key arguments in the platform modules finds half of
them; anything built at import time is an ordinary object in a module level
list. It checks both directions, since both halves were present here at once,
eight entities without a name and eight names without an entity, and that no
language file invents a key English does not have. Languages are allowed to lag
behind, several of these are incomplete on purpose and fall back to English per
key. Reverting the rename turns the test red on exactly the two platforms
affected.

Entity ids that were already registered as _2 keep those ids: the registry is
sticky, so the names come back on the next restart while the ids need a manual
rename. Nothing here changes a key, so no migration is involved.


Closes #614

## Summary by Sourcery

Align translation keys with entity descriptions so all entities resolve to their intended names and prevent future drift between code and translation files.

New Features:
- Introduce translation guard tests ensuring entity descriptions have corresponding names and translation keys are consistently declared across English and localized files.

Bug Fixes:
- Restore missing names for eight entities whose translation keys previously did not resolve, avoiding unnamed entities and duplicate IDs with `_2` suffixes.

Enhancements:
- Synchronize `strings.json` and `translations/en.json` entity key sets and ensure localized translation files do not introduce undeclared keys.