### PR TITLE
Give the LWZ climate entity back the features it inherits

### DIFF
--- a/custom_components/stiebel_eltron_isg/climate.py
+++ b/custom_components/stiebel_eltron_isg/climate.py
@@ -480,9 +480,7 @@ class StiebelEltronLWZClimateEntity(StiebelEltronISGClimateEntity):
         ]
         self._attr_fan_modes = [FAN_OFF, FAN_LOW, FAN_MEDIUM, FAN_HIGH]
         super().__init__(coordinator, config_entry, description)
-        self._attr_supported_features = (
-            ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
-        )
+        self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
 
     @property
     def operation_mode(self) -> int:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -2,10 +2,12 @@
 
 from types import SimpleNamespace
 
+from homeassistant.components.climate import ClimateEntityFeature
 from homeassistant.components.climate.const import FAN_HIGH, FAN_LOW
 
 from custom_components.stiebel_eltron_isg.climate import (
     ECO_MODE,
+    LWZ_CLIMATE_TYPES,
     StiebelEltronLWZClimateEntity,
     StiebelEltronWPMClimateEntity,
 )
@@ -19,6 +21,25 @@ def test_climate_unavailable_when_last_update_failed() -> None:
     # last_update_success is False, so availability must short-circuit to False
     # without evaluating the (stale) target temperature.
     assert entity.available is False
+
+
+def test_lwz_climate_preserves_supported_features() -> None:
+    """LWZ fan support must not replace the features inherited from the base."""
+    coordinator = SimpleNamespace(device_info={})
+    config_entry = SimpleNamespace(entry_id="test")
+
+    entity = StiebelEltronLWZClimateEntity(
+        coordinator, config_entry, LWZ_CLIMATE_TYPES[0]
+    )
+
+    required_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.PRESET_MODE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.FAN_MODE
+    )
+    assert entity.supported_features & required_features == required_features
 
 
 class _FakeSystemParameters:


### PR DESCRIPTION
`StiebelEltronLWZClimateEntity.__init__` assigned a fresh
`supported_features` mask of `TARGET_TEMPERATURE | FAN_MODE` after calling
`super().__init__()`.

The base class had already put `PRESET_MODE`, `TURN_ON` and `TURN_OFF` there,
so the subclass did not add fan support: it replaced everything the base had
declared.

Those flags are how Home Assistant decides which controls a climate entity
offers. The LWZ entity implements presets and inherits the turn methods, but
without their flags those capabilities are not advertised. The frontend can
therefore hide preset and power controls from an entity that supports both.

The fix is `|=` instead of `=`, so `FAN_MODE` is added to the inherited mask
rather than substituted for it.

### The guard

`test_lwz_climate_preserves_supported_features` constructs the entity from
`LWZ_CLIMATE_TYPES[0]` and asserts all five feature groups are present at once.

Checking `FAN_MODE` alone would pass on the broken code, because that was one
of the two flags the replacement mask kept. The regression is the combination:
fan support must not cost target temperature, presets or power controls.

### Verification

- 560 passed, 4 skipped
- `ruff check` and `ruff format --check` clean

## Summary by Sourcery

Preserve inherited climate entity features while adding LWZ fan support and add a regression test to ensure all expected features remain advertised.

Bug Fixes:
- Fix LWZ climate entity so adding fan support no longer overwrites inherited supported feature flags for presets and power controls.

Tests:
- Add regression test verifying LWZ climate entities expose target temperature, presets, power controls, and fan mode simultaneously.