### PR TITLE
Stop compiling statistics from ISG day counters that retain a residue

### DIFF
--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-import datetime
 import logging
 from typing import Any
 
@@ -24,7 +23,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-import homeassistant.util.dt as dt_util
 from pystiebeleltron import ControllerModel
 
 from .const import (
@@ -232,13 +230,19 @@ def create_daily_energy_entity_description(
     modbus_register: StiebelEltronModbusRegister,
     visible_default: bool = True,
 ) -> StiebelEltronSensorEntityDescription:
-    """Create an entry description for a energy sensor."""
+    """Create a sensor for an ISG day register.
+
+    At midnight the device transfers only whole kWh to its total register and
+    retains the fractional residue here. A state class would make Home Assistant
+    compile a misleading long-term sum: a detected reset assumes a zero baseline
+    and counts the retained residue again. The day register remains useful as an
+    operational value; the separate cumulative sensors provide energy statistics.
+    """
     return StiebelEltronSensorEntityDescription(
         key=key,
         translation_key=key,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         icon="mdi:meter-electric",
-        state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.ENERGY,
         entity_registry_visible_default=visible_default,
         modbus_register=modbus_register,
@@ -1177,7 +1181,7 @@ async def async_setup_entry(
             for description in WPM_3I_SENSOR_TYPES
         ]
         daily_energy_entities = [
-            StiebelEltronISGEnergySensor(
+            StiebelEltronISGSensor(
                 coordinator,
                 entry,
                 description,
@@ -1199,7 +1203,7 @@ async def async_setup_entry(
             for description in WPM_SENSOR_TYPES
         ]
         daily_energy_entities = [
-            StiebelEltronISGEnergySensor(
+            StiebelEltronISGSensor(
                 coordinator,
                 entry,
                 description,
@@ -1226,7 +1230,7 @@ async def async_setup_entry(
             for description in LWZ_SENSOR_TYPES
         ]
         daily_energy_entities = [
-            StiebelEltronISGEnergySensor(
+            StiebelEltronISGSensor(
                 coordinator,
                 entry,
                 description,
@@ -1263,26 +1267,3 @@ class StiebelEltronISGSensor(StiebelEltronISGEntity, SensorEntity):
                 return "no error"
             return f"error {error}"
         return self.coordinator.get_value(self.modbus_register)
-
-
-class StiebelEltronISGEnergySensor(StiebelEltronISGSensor):
-    """stiebel_eltron_isg Energy Sensor class."""
-
-    def __init__(
-        self,
-        coordinator: StiebelEltronDataCoordinator,
-        config_entry: StiebelEltronConfigEntry,
-        description: StiebelEltronSensorEntityDescription,
-    ):
-        """Initialize the sensor."""
-        super().__init__(coordinator, config_entry, description)
-
-    @property
-    def last_reset(self) -> datetime.datetime | None:
-        """Set Last Reset to now, if value is 0."""
-        if (
-            self.coordinator.has_value(self.modbus_register)
-            and self.coordinator.get_value(self.modbus_register) == 0
-        ):
-            return dt_util.utcnow()
-        return None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -216,10 +216,18 @@ async def test_daily_energy_sensors_do_not_report_poll_time_as_reset(
 
     await async_setup_entry(None, entry, entities.extend)
 
+    daily_description_keys = {description.key for description in daily_descriptions}
     daily_entities = [
-        entity for entity in entities if entity.entity_description in daily_descriptions
+        entity
+        for entity in entities
+        if entity.entity_description.key in daily_description_keys
     ]
-    assert daily_entities
+    daily_entity_keys = [entity.entity_description.key for entity in daily_entities]
+
+    assert daily_description_keys
+    assert len(daily_description_keys) == len(daily_descriptions)
+    assert len(daily_entity_keys) == len(daily_description_keys)
+    assert set(daily_entity_keys) == daily_description_keys
     assert all(type(entity) is StiebelEltronISGSensor for entity in daily_entities)
     assert all(entity.last_reset is None for entity in daily_entities)
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfEnergy, UnitOfFrequency, UnitOfPower
+from pystiebeleltron import ControllerModel
 import pytest
 
 from custom_components.stiebel_eltron_isg.const import (
@@ -13,27 +14,39 @@ from custom_components.stiebel_eltron_isg.const import (
     CONSUMED_COOLING_12M,
     CONSUMED_COOLING_LAST_24H,
     CONSUMED_COOLING_PREV_12M,
+    CONSUMED_HEATING,
     CONSUMED_HEATING_12M,
     CONSUMED_HEATING_LAST_24H,
     CONSUMED_HEATING_PREV_12M,
+    CONSUMED_HEATING_TOTAL,
+    CONSUMED_WATER_HEATING,
     CONSUMED_WATER_HEATING_12M,
     CONSUMED_WATER_HEATING_LAST_24H,
     CONSUMED_WATER_HEATING_PREV_12M,
+    CONSUMED_WATER_HEATING_TOTAL,
     COOLING_RUNTIME,
     CURRENT_POWER_CONSUMPTION,
     PRODUCED_ELECTRICAL_BOOSTER_HEATING_TOTAL,
     PRODUCED_ELECTRICAL_BOOSTER_WATER_HEATING_TOTAL,
+    PRODUCED_HEATING,
+    PRODUCED_HEATING_TOTAL,
     PRODUCED_SOLAR_HEATING,
     PRODUCED_SOLAR_HEATING_TOTAL,
     PRODUCED_SOLAR_WATER_HEATING,
     PRODUCED_SOLAR_WATER_HEATING_TOTAL,
+    PRODUCED_WATER_HEATING,
+    PRODUCED_WATER_HEATING_TOTAL,
     TARGET_TEMPERATURE_HK1,
 )
 from custom_components.stiebel_eltron_isg.sensor import (
+    ENERGY_DAILY_SENSOR_TYPES,
+    LWZ_ENERGY_DAILY_SENSOR_TYPES,
     LWZ_SENSOR_TYPES,
     WPM_3I_SENSOR_TYPES,
     WPM_INVERTER_POWER_SENSOR_TYPES,
     WPM_SENSOR_TYPES,
+    StiebelEltronISGSensor,
+    async_setup_entry,
 )
 
 
@@ -148,6 +161,67 @@ def test_wpm_exposes_power_consumption_statistics() -> None:
         assert desc.device_class == SensorDeviceClass.ENERGY
         # Rolling windows reset, so they must not be TOTAL_INCREASING.
         assert desc.state_class == SensorStateClass.TOTAL
+
+
+@pytest.mark.parametrize(
+    "descriptions", [ENERGY_DAILY_SENSOR_TYPES, LWZ_ENERGY_DAILY_SENSOR_TYPES]
+)
+def test_daily_energy_sensors_do_not_generate_long_term_sums(descriptions) -> None:
+    """Day-register residue makes zero-based long-term sums inaccurate."""
+    for description in descriptions:
+        assert description.native_unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR
+        assert description.device_class == SensorDeviceClass.ENERGY
+        assert description.state_class is None
+
+
+CUMULATIVE_ENERGY_KEYS = {
+    PRODUCED_HEATING,
+    PRODUCED_HEATING_TOTAL,
+    PRODUCED_WATER_HEATING,
+    PRODUCED_WATER_HEATING_TOTAL,
+    CONSUMED_HEATING,
+    CONSUMED_HEATING_TOTAL,
+    CONSUMED_WATER_HEATING,
+    CONSUMED_WATER_HEATING_TOTAL,
+}
+
+
+@pytest.mark.parametrize(
+    "descriptions", [WPM_3I_SENSOR_TYPES, WPM_SENSOR_TYPES, LWZ_SENSOR_TYPES]
+)
+def test_cumulative_energy_sensors_remain_total_increasing(descriptions) -> None:
+    """Cumulative alternatives remain suitable for long-term energy sums."""
+    descriptions_by_key = {description.key: description for description in descriptions}
+    assert descriptions_by_key.keys() >= CUMULATIVE_ENERGY_KEYS
+
+    for key in CUMULATIVE_ENERGY_KEYS:
+        assert descriptions_by_key[key].state_class == SensorStateClass.TOTAL_INCREASING
+
+
+@pytest.mark.parametrize(
+    ("model", "daily_descriptions"),
+    [
+        (ControllerModel.WPM_3i, ENERGY_DAILY_SENSOR_TYPES),
+        (ControllerModel.WPM_3, ENERGY_DAILY_SENSOR_TYPES),
+        (ControllerModel.LWZ, LWZ_ENERGY_DAILY_SENSOR_TYPES),
+    ],
+)
+async def test_daily_energy_sensors_do_not_report_poll_time_as_reset(
+    model, daily_descriptions
+) -> None:
+    """Day registers must not invent a new reset timestamp on each zero poll."""
+    coordinator = SimpleNamespace(model=model, device_info={})
+    entry = SimpleNamespace(runtime_data=coordinator, entry_id="test")
+    entities = []
+
+    await async_setup_entry(None, entry, entities.extend)
+
+    daily_entities = [
+        entity for entity in entities if entity.entity_description in daily_descriptions
+    ]
+    assert daily_entities
+    assert all(type(entity) is StiebelEltronISGSensor for entity in daily_entities)
+    assert all(entity.last_reset is None for entity in daily_entities)
 
 
 test_wpm_exposes_electrical_booster_energy_test_data = [_wpm, _wpm_3i]


### PR DESCRIPTION
The daily energy sensors carried `SensorStateClass.TOTAL` and, through
`StiebelEltronISGEnergySensor`, a `last_reset` timestamp computed while polling.

Both rest on an assumption about the ISG day registers that does not hold. The
result is a long-term statistic whose drops at midnight do not mean what Home
Assistant thinks they mean.

### What the device does at midnight

Stiebel Eltron support states that only the whole-kWh portion moves from a day
register into its cumulative register at midnight. The fractional part stays
behind: a value of 3.8 kWh becomes 0.8 kWh, not zero.

That makes the register neither a monotonic meter nor a clean per-day delta. A
nonzero value can consist entirely of residue carried from earlier days.

The current `TOTAL` state class treats the drop as a negative delta, so the
compiled sum falls when whole kWh move into the cumulative register. Changing
it to `TOTAL_INCREASING` does not solve that: its reset detection starts the new
cycle from a zero baseline and counts the retained 0.8 kWh again.

The `last_reset` property does not describe the device transition either. It
returns `dt_util.utcnow()` only when a poll happens to read exactly zero. With a
retained residue that is usually not the midnight value, and even when zero is
read, the timestamp says when Home Assistant polled rather than when the device
rolled over.

There is therefore no correct Home Assistant statistics state class for these
registers.

The day sensors keep their `ENERGY` device class, kWh unit, entity keys and
current state, but no longer produce long-term statistics. They continue to
show the device's day-register value, including any retained residue.

`StiebelEltronISGEnergySensor` existed only for the `last_reset` workaround and
is removed with it. The platform now creates ordinary
`StiebelEltronISGSensor` instances for the day registers.

### Where energy statistics come from instead

The separate day-and-total and lifetime sensors are unchanged and remain
`TOTAL_INCREASING`. Those are the cumulative alternatives intended for the
Energy Dashboard.

The day-and-total sensors combine the cumulative register with the current day
register, including the retained fractional residue. Home Assistant derives
daily, weekly and monthly consumption from changes in this cumulative value.
This provides accurate period statistics without treating the raw day register
as a clean daily delta.

The tests assert that all eight common cumulative keys remain present and
`TOTAL_INCREASING` on WPM 3i, WPM and LWZ. Removing the state class from the day
registers must not turn into removing valid statistics generally.

### What changes for existing installations

A daily sensor without a state class can no longer be used as an Energy
Dashboard source. Anyone currently using one has to select the corresponding
cumulative sensor instead.

Previously compiled statistics are not converted automatically. They were
created under the old day-register semantics and belong to a different
statistic id than the cumulative replacement. Home Assistant may flag the
removed state class under Developer Tools → Statistics; affected users should
review and remove or repair the old statistic there.

Keeping `TOTAL` merely to avoid that transition would continue producing a sum
that moves backwards at the midnight transfer.

### The guards

Three tests cover different ways this could regress:

- The description tests assert `state_class is None` while the energy device
  class and kWh unit remain, for both the WPM and LWZ daily lists.
- `test_cumulative_energy_sensors_remain_total_increasing` covers the WPM 3i,
  WPM and LWZ alternatives.
- `test_daily_energy_sensors_do_not_report_poll_time_as_reset` calls
  `async_setup_entry` for all three model paths and inspects the entities the
  platform actually creates. They must be plain `StiebelEltronISGSensor`
  instances with no `last_reset`.

The last test matters because description-only assertions would not notice if
the platform continued instantiating the old subclass.

### Verification

- 567 passed, 4 skipped
- `ruff check` and `ruff format --check` clean

## Summary by Sourcery

Stop exposing ISG daily energy counters as long-term statistics and rely on cumulative sensors for energy tracking instead.

Bug Fixes:
- Prevent misleading long-term energy statistics derived from ISG daily registers that retain fractional residues across midnights.

Enhancements:
- Treat ISG daily energy registers as regular energy sensors without a statistics state class or synthetic last_reset timestamps.
- Remove the dedicated energy sensor subclass and create standard sensors for daily energy entities across supported controller models.

Tests:
- Add tests ensuring daily energy descriptions keep energy units but no state class, while cumulative energy sensors remain TOTAL_INCREASING.
- Add integration tests verifying that daily energy entities are plain sensor instances without last_reset and that all expected cumulative keys are still exposed.