### PR TITLE
Let a write that cannot succeed say so

### DIFF
--- a/custom_components/stiebel_eltron_isg/button.py
+++ b/custom_components/stiebel_eltron_isg/button.py
@@ -84,6 +84,5 @@ class StiebelEltronISGButtonEntity(StiebelEltronISGEntity, ButtonEntity):
 
     @property
     def available(self) -> bool:
-        """Return True if entity is available."""
-
-        return True  # The button is always available as it doesn't rely on specific data from the coordinator
+        """Follow connectivity without requiring a data field like other entities."""
+        return self.coordinator.last_update_success

--- a/custom_components/stiebel_eltron_isg/coordinator.py
+++ b/custom_components/stiebel_eltron_isg/coordinator.py
@@ -12,6 +12,7 @@ from typing import Any, Protocol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from modbus_connection import ModbusConnection, ModbusUnit
@@ -27,6 +28,15 @@ from custom_components.stiebel_eltron_isg.const import (
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 type StiebelEltronConfigEntry = ConfigEntry[StiebelEltronDataCoordinator]
+
+
+def _is_read_only_write_error(err: AttributeError, field: str) -> bool:
+    """Return whether modbus_connection rejected a read-only field or space."""
+    message = str(err)
+    return message == f"{field} is read-only" or (
+        message.startswith(f"{field} is in the ")
+        and message.endswith(" register space, which is read-only")
+    )
 
 
 def coordinator_display_name(model: ControllerModel) -> str:
@@ -180,8 +190,48 @@ class StiebelEltronDataCoordinator[T: StiebelEltronApi](DataUpdateCoordinator):
     ) -> None:
         """Write a value to a component field."""
         component_obj = getattr(self._api, component, None)
-        if component_obj is not None and hasattr(component_obj, field):
+        if component_obj is None or not hasattr(component_obj, field):
+            _LOGGER.debug("Write target %s.%s is unsupported", component, field)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="write_unsupported",
+                translation_placeholders={"field": field},
+            )
+
+        try:
             await component_obj.write(field, value)
+        except ValueError as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_write_value",
+                translation_placeholders={
+                    "field": field,
+                    "value": str(value),
+                },
+            ) from err
+        except AttributeError as err:
+            # Only translate the two documented read-only errors. An unrelated
+            # AttributeError from inside the library is a programming error and
+            # must remain visible.
+            if not _is_read_only_write_error(err, field):
+                raise
+            _LOGGER.debug(
+                "Write target %s.%s is read-only",
+                component,
+                field,
+                exc_info=True,
+            )
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="write_unsupported",
+                translation_placeholders={"field": field},
+            ) from err
+        except (ModbusError, StiebelEltronModbusError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="write_failed",
+                translation_placeholders={"field": field},
+            ) from err
 
     async def async_reset_heatpump(self) -> None:
         """Reset the heat pump."""

--- a/custom_components/stiebel_eltron_isg/lwz_coordinator.py
+++ b/custom_components/stiebel_eltron_isg/lwz_coordinator.py
@@ -50,7 +50,4 @@ class StiebelEltronModbusLWZDataCoordinator(
     async def async_reset_heatpump(self) -> None:
         """Reset the heat pump."""
         _LOGGER.debug("Reset the heat pump")
-        await self._api.system_parameters.write(
-            "reset",
-            1,
-        )
+        await self.write_component_value("system_parameters", "reset", 1)

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -48,6 +48,17 @@
             }
         }
     },
+    "exceptions": {
+        "write_unsupported": {
+            "message": "The setting {field} cannot be written on the connected controller."
+        },
+        "invalid_write_value": {
+            "message": "The value {value} is not valid for the setting {field}."
+        },
+        "write_failed": {
+            "message": "The setting {field} could not be written because communication with the heat pump failed."
+        }
+    },
     "entity": {
         "sensor": {
             "actual_temperature": {

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -48,6 +48,17 @@
             }
         }
     },
+    "exceptions": {
+        "write_unsupported": {
+            "message": "Die Einstellung {field} kann bei der verbundenen Regelung nicht geschrieben werden."
+        },
+        "invalid_write_value": {
+            "message": "Der Wert {value} ist für die Einstellung {field} ungültig."
+        },
+        "write_failed": {
+            "message": "Die Einstellung {field} konnte wegen eines Kommunikationsfehlers mit der Wärmepumpe nicht geschrieben werden."
+        }
+    },
     "entity": {
         "sensor": {
             "actual_temperature": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -37,6 +37,17 @@
             }
         }
     },
+    "exceptions": {
+        "write_unsupported": {
+            "message": "The setting {field} cannot be written on the connected controller."
+        },
+        "invalid_write_value": {
+            "message": "The value {value} is not valid for the setting {field}."
+        },
+        "write_failed": {
+            "message": "The setting {field} could not be written because communication with the heat pump failed."
+        }
+    },
     "entity": {
         "sensor": {
             "actual_temperature": {

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,51 @@
+"""Tests for the button platform."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from modbus_connection import ModbusError
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.stiebel_eltron_isg.button import StiebelEltronISGButtonEntity
+from custom_components.stiebel_eltron_isg.const import DOMAIN, RESET_HEATPUMP
+from custom_components.stiebel_eltron_isg.entity import build_unique_id
+
+
+@pytest.mark.parametrize("last_update_success", [True, False])
+def test_reset_button_availability_follows_coordinator(
+    last_update_success: bool,
+) -> None:
+    """The reset action must not be offered while the device is unavailable."""
+    entity = StiebelEltronISGButtonEntity.__new__(StiebelEltronISGButtonEntity)
+    entity.coordinator = SimpleNamespace(last_update_success=last_update_success)
+
+    assert entity.available is last_update_success
+
+
+async def test_reset_button_becomes_unavailable_after_failed_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_wpm_api: MagicMock,
+) -> None:
+    """A failed coordinator refresh is reflected in the HA entity state."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "button",
+        DOMAIN,
+        build_unique_id(mock_config_entry, RESET_HEATPUMP),
+    )
+    assert entity_id is not None
+    assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
+
+    mock_wpm_api.async_update.side_effect = ModbusError("update failed")
+    await mock_config_entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,194 @@
+"""Tests for coordinator write actions."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from modbus_connection import ModbusError
+from pystiebeleltron import StiebelEltronModbusError
+import pytest
+
+from custom_components.stiebel_eltron_isg.const import DOMAIN
+from custom_components.stiebel_eltron_isg.coordinator import (
+    StiebelEltronDataCoordinator,
+)
+from custom_components.stiebel_eltron_isg.lwz_coordinator import (
+    StiebelEltronModbusLWZDataCoordinator,
+)
+
+
+def _coordinator(api) -> StiebelEltronDataCoordinator:
+    """Build a coordinator without invoking Home Assistant setup."""
+    coordinator = StiebelEltronDataCoordinator.__new__(StiebelEltronDataCoordinator)
+    coordinator._api = api
+    return coordinator
+
+
+async def test_write_component_value_writes_supported_field() -> None:
+    """A supported field is passed to the library unchanged."""
+    component = SimpleNamespace(target=21.0, write=AsyncMock())
+    coordinator = _coordinator(SimpleNamespace(parameters=component))
+
+    await coordinator.write_component_value("parameters", "target", 22.0)
+
+    component.write.assert_awaited_once_with("target", 22.0)
+
+
+@pytest.mark.parametrize(
+    ("api", "component", "field"),
+    [
+        pytest.param(SimpleNamespace(), "missing", "target", id="missing-component"),
+        pytest.param(
+            SimpleNamespace(parameters=SimpleNamespace(write=AsyncMock())),
+            "parameters",
+            "missing",
+            id="missing-field",
+        ),
+    ],
+)
+async def test_write_component_value_rejects_unsupported_target(
+    api,
+    component: str,
+    field: str,
+) -> None:
+    """Missing components and fields must not silently swallow an action."""
+    coordinator = _coordinator(api)
+
+    with pytest.raises(HomeAssistantError) as error:
+        await coordinator.write_component_value(component, field, 22.0)
+
+    assert type(error.value) is HomeAssistantError
+    assert error.value.translation_domain == DOMAIN
+    assert error.value.translation_key == "write_unsupported"
+    assert error.value.translation_placeholders == {"field": field}
+
+
+@pytest.mark.parametrize(
+    "read_only_error",
+    [
+        pytest.param(
+            AttributeError("target is read-only"),
+            id="read-only-field",
+        ),
+        pytest.param(
+            AttributeError("target is in the input register space, which is read-only"),
+            id="read-only-space",
+        ),
+    ],
+)
+async def test_write_component_value_reports_read_only_field(
+    read_only_error: AttributeError,
+) -> None:
+    """The library's read-only error is exposed as a translated HA error."""
+    component = SimpleNamespace(
+        target=21.0,
+        write=AsyncMock(side_effect=read_only_error),
+    )
+    coordinator = _coordinator(SimpleNamespace(parameters=component))
+
+    with pytest.raises(HomeAssistantError) as error:
+        await coordinator.write_component_value("parameters", "target", 22.0)
+
+    assert type(error.value) is HomeAssistantError
+    assert error.value.translation_key == "write_unsupported"
+    assert error.value.__cause__ is read_only_error
+
+
+async def test_write_component_value_reports_invalid_value() -> None:
+    """Library validation failures are service validation errors."""
+    component = SimpleNamespace(
+        target=21.0,
+        write=AsyncMock(side_effect=ValueError("outside allowed range")),
+    )
+    coordinator = _coordinator(SimpleNamespace(parameters=component))
+
+    with pytest.raises(ServiceValidationError) as error:
+        await coordinator.write_component_value("parameters", "target", 99.0)
+
+    assert type(error.value) is ServiceValidationError
+    assert error.value.translation_domain == DOMAIN
+    assert error.value.translation_key == "invalid_write_value"
+    assert error.value.translation_placeholders == {
+        "field": "target",
+        "value": "99.0",
+    }
+    assert isinstance(error.value.__cause__, ValueError)
+
+
+@pytest.mark.parametrize(
+    "write_error",
+    [
+        pytest.param(ModbusError("write failed"), id="modbus"),
+        pytest.param(StiebelEltronModbusError(), id="library"),
+    ],
+)
+async def test_write_component_value_reports_communication_error(
+    write_error: Exception,
+) -> None:
+    """Communication failures are exposed as translated HA errors."""
+    component = SimpleNamespace(
+        target=21.0,
+        write=AsyncMock(side_effect=write_error),
+    )
+    coordinator = _coordinator(SimpleNamespace(parameters=component))
+
+    with pytest.raises(HomeAssistantError) as error:
+        await coordinator.write_component_value("parameters", "target", 22.0)
+
+    assert type(error.value) is HomeAssistantError
+    assert error.value.translation_domain == DOMAIN
+    assert error.value.translation_key == "write_failed"
+    assert error.value.translation_placeholders == {"field": "target"}
+    assert error.value.__cause__ is write_error
+
+
+@pytest.mark.parametrize(
+    "write_error",
+    [
+        pytest.param(RuntimeError("boom"), id="runtime-error"),
+        pytest.param(
+            AttributeError("'NoneType' object has no attribute 'address'"),
+            id="unrelated-attribute-error",
+        ),
+    ],
+)
+async def test_write_component_value_propagates_unexpected_error(
+    write_error: Exception,
+) -> None:
+    """Unexpected library defects must not be disguised as device limitations."""
+    component = SimpleNamespace(
+        target=21.0,
+        write=AsyncMock(side_effect=write_error),
+    )
+    coordinator = _coordinator(SimpleNamespace(parameters=component))
+
+    with pytest.raises(type(write_error)) as error:
+        await coordinator.write_component_value("parameters", "target", 22.0)
+
+    assert error.value is write_error
+
+
+async def test_reset_heatpump_uses_wpm_reset_value() -> None:
+    """The base WPM coordinator resets with the WPM-specific value."""
+    coordinator = _coordinator(SimpleNamespace())
+    coordinator.write_component_value = AsyncMock()
+
+    await coordinator.async_reset_heatpump()
+
+    coordinator.write_component_value.assert_awaited_once_with(
+        "system_parameters", "reset", 3
+    )
+
+
+async def test_lwz_reset_heatpump_uses_central_write_path() -> None:
+    """LWZ keeps its value 1 while using the shared error handling."""
+    coordinator = StiebelEltronModbusLWZDataCoordinator.__new__(
+        StiebelEltronModbusLWZDataCoordinator
+    )
+    coordinator.write_component_value = AsyncMock()
+
+    await coordinator.async_reset_heatpump()
+
+    coordinator.write_component_value.assert_awaited_once_with(
+        "system_parameters", "reset", 1
+    )


### PR DESCRIPTION
`write_component_value` guarded its write with `getattr(..., None)` and
`hasattr`.

When a component or field was absent from a model's API, the method returned
normally. Home Assistant saw a service call that completed without error even
though nothing had been sent to the heat pump.

Failures one layer down were not any clearer. A read-only field, a value outside
the library's accepted range or a Modbus failure escaped as a raw library
exception instead of a Home Assistant error that says whether the setting, the
value or the connection was the problem.

### What each failure becomes

- Missing component or field:
  `HomeAssistantError` with `write_unsupported`. This is the case that used to
  be silent.
- A field or register space the library marks read-only:
  `HomeAssistantError` with the same translated `write_unsupported` message.
- A `ValueError` from the library's write validator:
  `ServiceValidationError` with `invalid_write_value`, carrying the field and
  rejected value.
- `ModbusError` or `StiebelEltronModbusError`:
  `HomeAssistantError` with `write_failed`.

The exceptions caught from the library are chained with `from err`, so their
original message and traceback remain available in the log. A component or
field rejected before the library write has no lower-level exception to chain.

### Why AttributeError is matched narrowly

The current `modbus_connection` write path reports a read-only target with one
of two `AttributeError` message forms:

```text
<field> is read-only
<field> is in the <space> register space, which is read-only
```

`_is_read_only_write_error` matches those two shapes and nothing else.

That narrowness is intentional. An unrelated `AttributeError` raised inside the
library is a programming defect, not a controller limitation. Catching the
whole exception class would relabel it as “this setting cannot be written on
the connected controller” and make the hardware look responsible for a code
error.

Unmatched `AttributeError` and unrelated exceptions such as `RuntimeError`
therefore propagate unchanged.

The trade-off is the dependency on the library's message contract. If those
strings change, a read-only write becomes a loud raw error again rather than
being silently misclassified. That is the safer failure direction.

### The reset button

The reset button's `available` property always returned `True` because the
button has no value of its own to read from the coordinator.

It still needs a working connection to do anything useful. While the last
coordinator update had failed, Home Assistant continued offering an action
whose write could only fail. The button now follows
`coordinator.last_update_success`.

The LWZ coordinator also wrote its reset directly through
`self._api.system_parameters.write`, bypassing the shared path. It now calls
`write_component_value` as well.

The controller-specific values do not change:

- WPM reset: `3`
- LWZ reset: `1`

Both are pinned by tests so sharing the error path cannot quietly turn them
into one common value.

### The guards

`tests/test_coordinator.py` covers every error class and asserts the exact type,
not merely `isinstance`. That distinction matters because
`ServiceValidationError` inherits from `HomeAssistantError`; an `isinstance`
assertion would not notice the two classifications collapsing into one.

The tests also assert translation keys, placeholders and exception causes. Two
cases run in the other direction: an unrelated `AttributeError` and a
`RuntimeError` must leave the coordinator unchanged.

`tests/test_button.py` checks availability at two levels. The small parametrised
test proves the property follows `last_update_success`. The integration-level
test sets up a real config entry, makes the next API update fail with
`ModbusError`, refreshes the coordinator and verifies that Home Assistant's
button state becomes `unavailable`.

That second test proves the rule reaches the state machine rather than merely
existing as a property on an isolated object.

### Translations

The three messages are added to `strings.json`, `en.json` and `de.json`. The
other languages fall back to English for these keys.

### Verification

- 574 passed, 4 skipped
- `ruff check` and `ruff format --check` clean

## Summary by Sourcery

Improve write error handling and reset behaviour so failed heat pump writes surface clear Home Assistant errors and the reset button respects coordinator connectivity.

Bug Fixes:
- Raise translated HomeAssistantError when attempting to write to missing or read-only components or fields instead of silently succeeding or exposing raw library exceptions.
- Classify invalid write values as ServiceValidationError and Modbus-level communication problems as translated HomeAssistantError, preserving original causes.
- Make the reset button unavailable when the coordinator last update failed so Home Assistant does not offer an action that cannot succeed.
- Ensure LWZ reset uses the shared write_component_value path without changing its controller-specific reset value.

Enhancements:
- Introduce targeted handling for known read-only AttributeError messages while allowing unexpected library errors to propagate unchanged.
- Align LWZ coordinator reset logic with the base coordinator, centralising write error handling.

Documentation:
- Add new translated error messages for unsupported writes, invalid write values and write failures in the English and German translation files, with other languages falling back to English.

Tests:
- Add coordinator tests covering supported writes, unsupported targets, read-only fields, invalid values, communication failures and unexpected library errors, including exact exception types and translations.
- Add button tests verifying availability follows coordinator.last_update_success and that a failed refresh results in an unavailable reset button entity state.