### PR TITLE
Keep the ISG host out of the diagnostics download

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,6 +15,12 @@ body:
         Settings → Devices and Services → Stiebel Eltron ISG → three-dot menu →
         Download diagnostics. It contains the detected controller and the decoded
         register values, which is what most of these reports come down to.
+        Current integration versions redact the configured host name or IP
+        address. Older versions may still include it, so always check the
+        `config_entry` section for a `host` field before uploading. The configured
+        name and port as well as operating values such as temperatures and energy
+        counters remain visible because they are useful for diagnosis. Please
+        remove anything you do not want to publish.
 
   - type: checkboxes
     attributes:
@@ -90,7 +96,10 @@ body:
       label: Diagnostics
       description: >
         Attach the diagnostics file by dragging it into this field, or paste its
-        contents. If you cannot provide it, say why here.
+        contents. Current versions redact the configured host automatically;
+        older versions may not. The configured name, port and operating values
+        remain visible. Review the file before posting it. If you cannot provide
+        it, say why here.
     validations:
       required: true
 

--- a/custom_components/stiebel_eltron_isg/diagnostics.py
+++ b/custom_components/stiebel_eltron_isg/diagnostics.py
@@ -2,16 +2,43 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Final
 
 from homeassistant.components.diagnostics.util import async_redact_data
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .coordinator import StiebelEltronConfigEntry
 
-CONFIG_FIELDS_TO_REDACT: list[str] = []
-DATA_FIELDS_TO_REDACT: list[str] = []
+CONFIG_FIELDS_TO_REDACT: Final[set[str]] = {CONF_HOST}
+# async_redact_data also converts ConfigEntry.options from MappingProxyType to
+# a plain JSON-safe dict, even while there are no sensitive option fields.
+OPTIONS_FIELDS_TO_REDACT: Final[set[str]] = set()
+# Audited against pinned pystiebeleltron 0.6.2: its Modbus fields contain no
+# serial, MAC, host or IP identifiers. Re-audit this set on dependency updates;
+# other ISG interfaces can expose a MAC-based serial number.
+DATA_FIELDS_TO_REDACT: Final[set[str]] = set()
+
+
+def _diagnostics_for_entry(
+    entry: StiebelEltronConfigEntry,
+) -> dict[str, Any]:
+    """Build diagnostics shared by the config entry and device endpoints."""
+    coordinator = entry.runtime_data
+    data = {str(k): v for k, v in coordinator.get_raw_data().items() if v is not None}
+
+    return {
+        "config_entry": async_redact_data(entry.data, CONFIG_FIELDS_TO_REDACT),
+        "options": async_redact_data(entry.options, OPTIONS_FIELDS_TO_REDACT),
+        "data": [
+            async_redact_data(data, DATA_FIELDS_TO_REDACT),
+            {
+                "model": coordinator.model.name,
+                "model_id": coordinator.model.value,
+            },
+        ],
+    }
 
 
 async def async_get_config_entry_diagnostics(
@@ -19,18 +46,7 @@ async def async_get_config_entry_diagnostics(
     entry: StiebelEltronConfigEntry,
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator = entry.runtime_data
-
-    data = {str(k): v for k, v in coordinator.get_raw_data().items() if v is not None}
-
-    return {
-        "config_entry": async_redact_data(entry.data, CONFIG_FIELDS_TO_REDACT),
-        "options": async_redact_data(entry.options, []),
-        "data": [
-            async_redact_data(data, DATA_FIELDS_TO_REDACT),
-            {"model": coordinator.model},
-        ],
-    }
+    return _diagnostics_for_entry(entry)
 
 
 async def async_get_device_diagnostics(
@@ -38,16 +54,5 @@ async def async_get_device_diagnostics(
     config_entry: StiebelEltronConfigEntry,
     device: DeviceEntry,
 ) -> dict[str, Any]:
-    """Return diagnostics for a device."""
-    coordinator = config_entry.runtime_data
-
-    data = {str(k): v for k, v in coordinator.get_raw_data().items() if v is not None}
-
-    return {
-        "config_entry": async_redact_data(config_entry.data, CONFIG_FIELDS_TO_REDACT),
-        "options": async_redact_data(config_entry.options, []),
-        "data": [
-            async_redact_data(data, DATA_FIELDS_TO_REDACT),
-            {"model": coordinator.model},
-        ],
-    }
+    """Return entry-scoped diagnostics for its single controller device."""
+    return _diagnostics_for_entry(config_entry)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,82 @@
+"""Tests for integration diagnostics."""
+
+import importlib.metadata
+import json
+from types import SimpleNamespace
+
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.json import ExtendedJSONEncoder
+from pystiebeleltron import ControllerModel
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.stiebel_eltron_isg.const import DOMAIN
+from custom_components.stiebel_eltron_isg.diagnostics import (
+    async_get_config_entry_diagnostics,
+    async_get_device_diagnostics,
+)
+
+
+def test_raw_data_privacy_audit_matches_dependency_version() -> None:
+    """A library update must trigger a new sensitive-field audit."""
+    assert importlib.metadata.version("pystiebeleltron") == "0.6.2"
+
+
+async def test_diagnostics_redact_host_and_preserve_useful_data(
+    hass: HomeAssistant,
+) -> None:
+    """Both diagnostics entry points protect the host without losing context."""
+    private_host = "private-isg.example.internal"
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: private_host,
+            CONF_PORT: 1502,
+            "name": "Ground floor heat pump",
+        },
+        options={"scan_interval": 60},
+    )
+    mock_config_entry.runtime_data = SimpleNamespace(
+        model=ControllerModel.WPM_3,
+        get_raw_data=lambda: {
+            "outside_temperature": 12.5,
+            "produced_heating_total": 12345,
+            "unsupported_value": None,
+        },
+    )
+
+    config_diagnostics = await async_get_config_entry_diagnostics(
+        hass, mock_config_entry
+    )
+    device_diagnostics = await async_get_device_diagnostics(
+        hass,
+        mock_config_entry,
+        SimpleNamespace(),
+    )
+
+    assert config_diagnostics == device_diagnostics
+    assert config_diagnostics["config_entry"] == {
+        CONF_HOST: REDACTED,
+        CONF_PORT: 1502,
+        "name": "Ground floor heat pump",
+    }
+    assert config_diagnostics["options"] == {"scan_interval": 60}
+    assert config_diagnostics["data"] == [
+        {
+            "outside_temperature": 12.5,
+            "produced_heating_total": 12345,
+        },
+        {"model": "WPM_3", "model_id": 390},
+    ]
+
+    for diagnostics in (config_diagnostics, device_diagnostics):
+        downloaded_json = json.dumps(diagnostics, cls=ExtendedJSONEncoder)
+        assert private_host not in downloaded_json
+        downloaded_diagnostics = json.loads(downloaded_json)
+        assert downloaded_diagnostics["config_entry"][CONF_HOST] == REDACTED
+        assert downloaded_diagnostics["config_entry"][CONF_PORT] == 1502
+        assert downloaded_diagnostics["data"][1] == {
+            "model": "WPM_3",
+            "model_id": 390,
+        }


### PR DESCRIPTION
`CONFIG_FIELDS_TO_REDACT` was empty, so both diagnostics endpoints included the
configured ISG host name or IP address unchanged.

The bug template asks reporters to attach that diagnostics file to an issue.
Without redaction, a value that is useful inside a local network can end up in a
public attachment.

`CONF_HOST` is now replaced with Home Assistant's standard `REDACTED` marker.
The information that makes the file useful stays: configured name and port,
options, controller model and decoded operating data.

### One payload, two endpoints

The config-entry and device endpoints contained two copies of the same payload.
The device endpoint did not use its device argument because one integration
entry represents one controller.

Both now call `_diagnostics_for_entry`. A future redaction or payload change
therefore cannot be applied to one endpoint and forgotten in the other. The
test asserts that both endpoints return the same data.

The existing `None` filter is kept: fields the controller does not provide are
omitted rather than emitted as null.

### The model field

The old payload handed a `ControllerModel` enum member directly to Home
Assistant's `ExtendedJSONEncoder`. The encoder falls back to a nested object
containing the enum type and its `repr`, which is valid JSON but unnecessarily
awkward for a diagnostics file.

The payload now contains both forms a reader can use directly:

```json
{
  "model": "WPM_3",
  "model_id": 390
}
```

The name is readable in an issue. The numeric id is the controller code used by
the library and register mapping.

### What the empty raw-data redaction set rests on

`DATA_FIELDS_TO_REDACT` remains empty, and that is an audited statement about a
specific dependency version rather than a general claim that Modbus data can
never identify a device.

The raw fields exposed by the pinned `pystiebeleltron 0.6.2` model contain no
serial number, MAC address, host name or IP address. Other ISG interfaces are
different: the WSS API can expose a serial number derived from the device MAC,
so a future library field or data source may require another redaction.

`test_raw_data_privacy_audit_matches_dependency_version` asserts that the
installed library is still exactly 0.6.2. A dependency bump deliberately breaks
that test until the field audit and its recorded version are updated.

`OPTIONS_FIELDS_TO_REDACT` is also an explicit empty set rather than a literal
`[]`. `async_redact_data` is still doing useful work there: it converts
`ConfigEntry.options` from its mapping proxy into a plain JSON-safe dictionary.
Naming the set records why that call should not be removed as an apparent
no-op.

### The bug template

The issue template now says that current integration versions redact the host
but older versions may not. It asks reporters to inspect the `config_entry`
section before uploading.

It also names what remains visible: configured name, port and operating values.
The diagnostics download is safer, not anonymised, and the template should not
suggest otherwise.

The change cannot sanitise a diagnostics file that was downloaded or attached
before this version.

### The guard

`test_diagnostics_redact_host_and_preserve_useful_data` builds an entry with a
recognisable host, calls both diagnostics endpoints and checks the expected
payload field by field.

It then serialises both results with `ExtendedJSONEncoder`, the encoder Home
Assistant uses for the diagnostics download, and asserts that the original host
string does not occur anywhere in the resulting JSON.

Checking the `host` key alone would not catch the same value leaking through a
second field or an object's fallback representation. The whole-document check
does.

The serialization round trip also pins the readable `model` and numeric
`model_id` representation.

### Verification

- 561 passed, 4 skipped
- issue-template YAML parses cleanly
- `ruff check` and `ruff format --check` clean

## Summary by Sourcery

Redact sensitive host information from diagnostics output while unifying diagnostics payload generation and improving diagnostics clarity and safety.

Bug Fixes:
- Ensure the configured ISG host name or IP address is redacted from diagnostics downloads to avoid leaking internal network details.

Enhancements:
- Share a single diagnostics payload builder between config-entry and device diagnostics endpoints so both always return identical data and benefit from future changes.
- Expose controller model information in diagnostics as a readable name plus numeric ID for easier interpretation and stable JSON encoding.
- Document that diagnostics redacts the host while leaving useful values visible, and instruct users to review files from older versions.

Tests:
- Add diagnostics tests that verify host redaction, preserved useful fields, consistent payloads across endpoints, and JSON encoding of the model information.
- Add a test that pins the pystiebeleltron dependency version to enforce re-auditing raw data fields on updates.