### PR TITLE
Cover the config flows and drop option strings without an options flow

### DIFF
--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -4,15 +4,16 @@
             "user": {
                 "description": "Enter the connection details for your Stiebel Eltron ISG heat pump.",
                 "data": {
-                    "name": "Name",
                     "host": "Host",
                     "port": "Port"
                 },
                 "data_description": {
-                    "name": "A name for this heat pump instance.",
                     "host": "The IP address or hostname of the Stiebel Eltron ISG web server.",
                     "port": "The Modbus TCP port of the ISG (default: 502)."
                 }
+            },
+            "discovery_confirm": {
+                "description": "Do you want to set up the Stiebel Eltron ISG at {host}?"
             },
             "reconfigure": {
                 "description": "Update the connection details for your Stiebel Eltron ISG heat pump.",
@@ -34,18 +35,6 @@
         "abort": {
             "already_configured": "Device is already configured",
             "reconfigure_successful": "Connection details updated successfully."
-        }
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "scan_interval": "Polling interval (seconds)"
-                },
-                "data_description": {
-                    "scan_interval": "How often the Modbus registers are polled, in seconds."
-                }
-            }
         }
     },
     "exceptions": {

--- a/custom_components/stiebel_eltron_isg/translations/cz.json
+++ b/custom_components/stiebel_eltron_isg/translations/cz.json
@@ -4,12 +4,10 @@
             "user": {
                 "description": "Zadejte přihlašovací údaje pro vaše tepelné čerpadlo Stiebel Eltron ISG.",
                 "data": {
-                    "name": "Název",
                     "host": "IP adresa Vašeho Stiebel Eltron ISG",
                     "port": "TCP port Vašeho Stiebel Eltron ISG (např. 502)"
                 },
                 "data_description": {
-                    "name": "Název pro tuto instanci tepelného čerpadla.",
                     "host": "IP adresa nebo název hostitele webového serveru Stiebel Eltron ISG.",
                     "port": "Modbus TCP port ISG (výchozí: 502)."
                 }
@@ -34,18 +32,6 @@
         "abort": {
             "already_configured": "Zařízení je už nakonfigurované.",
             "reconfigure_successful": "Připojovací údaje byly úspěšně aktualizovány."
-        }
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "scan_interval": "Interval dotazování (sekundy)"
-                },
-                "data_description": {
-                    "scan_interval": "Jak často jsou dotazovány Modbus registry, v sekundách."
-                }
-            }
         }
     },
     "entity": {

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -4,12 +4,10 @@
             "user": {
                 "description": "Geben Sie die Verbindungsdaten für Ihre Stiebel Eltron ISG Wärmepumpe ein.",
                 "data": {
-                    "name": "Name",
                     "host": "Die IP-Adresse des Stiebel Eltron ISG",
                     "port": "Der TCP Port des Stiebel Eltron ISG (z.B. 502)"
                 },
                 "data_description": {
-                    "name": "Ein Name für diese Wärmepumpen-Instanz.",
                     "host": "Die IP-Adresse oder der Hostname des Stiebel Eltron ISG Webservers.",
                     "port": "Der Modbus-TCP-Port des ISG (Standard: 502)."
                 }
@@ -34,18 +32,6 @@
         "abort": {
             "already_configured": "Das Gerät ist bereits konfiguriert.",
             "reconfigure_successful": "Verbindungsdaten erfolgreich aktualisiert."
-        }
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "scan_interval": "Abfrageintervall (Sekunden)"
-                },
-                "data_description": {
-                    "scan_interval": "Wie oft die Modbus-Register abgefragt werden, in Sekunden."
-                }
-            }
         }
     },
     "exceptions": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -4,12 +4,24 @@
             "user": {
                 "description": "Enter the connection details for your Stiebel Eltron ISG heat pump.",
                 "data": {
-                    "name": "Name",
                     "host": "The IP address of the Stiebel Eltron ISG",
                     "port": "The TCP port of the Stiebel Eltron ISG (e.g. 502)"
                 },
                 "data_description": {
-                    "name": "A name for this heat pump instance.",
+                    "host": "The IP address or hostname of the Stiebel Eltron ISG web server.",
+                    "port": "The Modbus TCP port of the ISG (default: 502)."
+                }
+            },
+            "discovery_confirm": {
+                "description": "Do you want to set up the Stiebel Eltron ISG at {host}?"
+            },
+            "reconfigure": {
+                "description": "Update the connection details for your Stiebel Eltron ISG heat pump.",
+                "data": {
+                    "host": "Host",
+                    "port": "Port"
+                },
+                "data_description": {
                     "host": "The IP address or hostname of the Stiebel Eltron ISG web server.",
                     "port": "The Modbus TCP port of the ISG (default: 502)."
                 }
@@ -23,18 +35,6 @@
         "abort": {
             "already_configured": "The device is already configured.",
             "reconfigure_successful": "Connection details updated successfully."
-        }
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "scan_interval": "Polling interval (seconds)"
-                },
-                "data_description": {
-                    "scan_interval": "How often the Modbus registers are polled, in seconds."
-                }
-            }
         }
     },
     "exceptions": {

--- a/custom_components/stiebel_eltron_isg/translations/fr.json
+++ b/custom_components/stiebel_eltron_isg/translations/fr.json
@@ -4,12 +4,10 @@
             "user": {
                 "description": "Entrez les détails de connexion pour votre pompe à chaleur Stiebel Eltron ISG.",
                 "data": {
-                    "name": "Nom",
                     "host": "L'adresse IP de votre ISG",
                     "port": "Le port TCP utilisé pour communiquer avec l'ISG"
                 },
                 "data_description": {
-                    "name": "Un nom pour cette instance de pompe à chaleur.",
                     "host": "L'adresse IP ou le nom d'hôte du serveur web ISG Stiebel Eltron.",
                     "port": "Le port TCP Modbus de l'ISG (défaut : 502)."
                 }
@@ -34,18 +32,6 @@
         "abort": {
             "already_configured": "Périphérique déjà configuré",
             "reconfigure_successful": "Les détails de connexion ont été mis à jour avec succès."
-        }
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "scan_interval": "Intervalle d'interrogation (secondes)"
-                },
-                "data_description": {
-                    "scan_interval": "La fréquence à laquelle les registres Modbus sont interrogés, en secondes."
-                }
-            }
         }
     },
     "entity": {

--- a/custom_components/stiebel_eltron_isg/translations/it.json
+++ b/custom_components/stiebel_eltron_isg/translations/it.json
@@ -4,12 +4,10 @@
             "user": {
                 "description": "Inserire i dettagli di connessione per la pompa di calore Stiebel Eltron ISG.",
                 "data": {
-                    "name": "Nome",
                     "host": "L'indirizzo IP del tuo ISG",
                     "port": "La porta TCP a cui connettersi all'ISG"
                 },
                 "data_description": {
-                    "name": "Un nome per questa istanza della pompa di calore.",
                     "host": "L'indirizzo IP o il nome host del server web ISG Stiebel Eltron.",
                     "port": "La porta TCP Modbus dell'ISG (predefinita: 502)."
                 }
@@ -34,18 +32,6 @@
         "abort": {
             "already_configured": "Il dispositivo è già configurato",
             "reconfigure_successful": "Dettagli di connessione aggiornati correttamente."
-        }
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "scan_interval": "Intervallo di polling (secondi)"
-                },
-                "data_description": {
-                    "scan_interval": "La frequenza con cui vengono interrogati i registri Modbus, in secondi."
-                }
-            }
         }
     },
     "entity": {

--- a/custom_components/stiebel_eltron_isg/translations/pt.json
+++ b/custom_components/stiebel_eltron_isg/translations/pt.json
@@ -4,12 +4,10 @@
             "user": {
                 "description": "Introduza os dados de ligação para a sua bomba de calor Stiebel Eltron ISG.",
                 "data": {
-                    "name": "Nome",
                     "host": "O endereço IP do ISG",
                     "port": "Porta TCP para ligação ao ISG"
                 },
                 "data_description": {
-                    "name": "Um nome para esta instância da bomba de calor.",
                     "host": "O endereço IP ou nome de host do servidor web ISG Stiebel Eltron.",
                     "port": "A porta TCP Modbus do ISG (predefinição: 502)."
                 }
@@ -34,18 +32,6 @@
         "abort": {
             "already_configured": "Equipamento já se encontra configurado.",
             "reconfigure_successful": "Detalhes de conexão atualizados com sucesso."
-        }
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "scan_interval": "Intervalo de pesquisa (segundos)"
-                },
-                "data_description": {
-                    "scan_interval": "Com que frequência os registos Modbus são consultados, em segundos."
-                }
-            }
         }
     },
     "entity": {

--- a/custom_components/stiebel_eltron_isg/translations/sk.json
+++ b/custom_components/stiebel_eltron_isg/translations/sk.json
@@ -4,12 +4,10 @@
             "user": {
                 "description": "Zadajte prihlasovacie údaje pre vaše tepelné čerpadlo Stiebel Eltron ISG.",
                 "data": {
-                    "name": "Názov",
                     "host": "IP adresa vášho ISG",
                     "port": "TCP port, na ktorom sa má pripojiť k ISG"
                 },
                 "data_description": {
-                    "name": "Názov pre túto inštanciu tepelného čerpadla.",
                     "host": "IP adresa alebo názov hostiteľa webového servera Stiebel Eltron ISG.",
                     "port": "Modbus TCP port ISG (predvolené: 502)."
                 }
@@ -34,18 +32,6 @@
         "abort": {
             "already_configured": "Zariadenie je už nakonfigurované",
             "reconfigure_successful": "Podrobnosti o pripojení boli úspešne aktualizované."
-        }
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "scan_interval": "Interval dotazovania (sekundy)"
-                },
-                "data_description": {
-                    "scan_interval": "Ako často sú dotazované Modbus registre, v sekundách."
-                }
-            }
         }
     },
     "entity": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -112,7 +112,6 @@ async def test_form_unknown_exception(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-@pytest.mark.skip(reason="lingering timer issue")
 async def test_reconfigure_flow(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -134,8 +133,11 @@ async def test_reconfigure_flow(
     assert result["reason"] == "reconfigure_successful"
     assert mock_config_entry.data[CONF_HOST] == "2.2.2.2"
 
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
-@pytest.mark.skip(reason="lingering timer issue")
+
 @pytest.mark.parametrize(
     ("side_effect", "expected_error"),
     [
@@ -173,6 +175,10 @@ async def test_reconfigure_flow_errors(
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
 
 async def test_reconfigure_flow_already_configured(

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -33,6 +33,7 @@ from custom_components.stiebel_eltron_isg import (
     binary_sensor,
     button,
     climate,
+    config_flow,
     number,
     select,
     sensor,
@@ -74,6 +75,13 @@ def _entity_names(file: pathlib.Path) -> dict[str, dict[str, dict]]:
 def _translation_keys(file: pathlib.Path, platform: str) -> set[str]:
     """Return the keys a translation file carries for one platform."""
     return set(_entity_names(file).get(platform, {}))
+
+
+def _key_tree(value):
+    """Return nested dictionary keys while ignoring translated text."""
+    if not isinstance(value, dict):
+        return None
+    return {key: _key_tree(child) for key, child in value.items()}
 
 
 @pytest.mark.parametrize("module", _PLATFORM_MODULES, ids=_platform)
@@ -140,6 +148,24 @@ def test_english_matches_strings() -> None:
         f"{_RUNTIME_FILE.name} entity keys differ from "
         f"{_STRINGS_FILE.name}: {differences}"
     )
+
+
+def test_english_config_flow_matches_strings() -> None:
+    """English runtime config-flow strings must carry every declared field."""
+    strings = json.loads(_STRINGS_FILE.read_text(encoding="utf-8"))["config"]
+    english = json.loads(_RUNTIME_FILE.read_text(encoding="utf-8"))["config"]
+
+    assert _key_tree(english) == _key_tree(strings)
+
+
+def test_config_flow_strings_match_runtime_fields() -> None:
+    """Config-flow strings must describe the fields and forms users can open."""
+    steps = json.loads(_STRINGS_FILE.read_text(encoding="utf-8"))["config"]["step"]
+    user_fields = {marker.schema for marker in config_flow.STEP_USER_DATA_SCHEMA.schema}
+
+    assert set(steps["user"]["data"]) == user_fields
+    assert set(steps["user"]["data_description"]) == user_fields
+    assert "description" in steps["discovery_confirm"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The config flow carried strings that no longer match the code: an
`options.step.init.scan_interval` block although there is no options flow and the
polling interval is fixed, and a `name` field although `STEP_USER_DATA_SCHEMA`
only asks for host and port. The `discovery_confirm` step, on the other hand, is
implemented in `config_flow.py` but had no description text at all. Two
reconfigure tests were skipped with "lingering timer issue", so the reconfigure
path was effectively untested.

## Changes

- Remove the `options` translation block from `strings.json` and all seven
  translation files. Nothing in the integration opens that form, so the entries
  only promise an option users cannot reach.
- Remove the `name` field labels from the user step; the schema has no such field.
- Add a `discovery_confirm` description so the DHCP confirmation dialog is not
  rendered from a raw step id.
- Add the missing `reconfigure` step to `translations/en.json`, which had drifted
  behind `strings.json`.
- Add the final newline that was missing in the cz, fr, it, pt and sk files.

## Tests

- `test_reconfigure_flow` and `test_reconfigure_flow_errors` no longer skip. The
  lingering timer came from leaving the entry loaded; both tests now block until
  done and unload the entry, so cleanup is deterministic rather than suppressed.
- `test_english_config_flow_matches_strings` compares the key tree of the English
  runtime file against `strings.json`, ignoring the translated text, so a future
  drift like the missing reconfigure step fails in CI.
- `test_config_flow_strings_match_runtime_fields` derives the expected field set
  from `STEP_USER_DATA_SCHEMA`, so a dead or missing field label is caught at the
  source instead of by reading JSON.

No config-entry behavior or dependency change. The visible copy now describes
the forms and fields that users can actually open.
Part of #629.

## Summary by Sourcery

Align stiebel_eltron_isg config flow translations with the actual runtime schema and ensure the reconfigure path and translation coverage are properly tested.

New Features:
- Add discovery confirmation and reconfigure step descriptions to the English config flow translations so DHCP and reconfigure dialogs render with meaningful text.

Bug Fixes:
- Remove obsolete options and name field strings from config flow translations that no longer correspond to any runtime fields or flows.
- Fix lingering timer issues in reconfigure tests by fully unloading the config entry at the end of the flows.

Enhancements:
- Ensure English config flow translations remain in sync with strings.json via a key-tree comparison test.
- Validate that config flow string definitions match the fields derived from STEP_USER_DATA_SCHEMA so missing or dead field labels are caught early.

Documentation:
- Normalize translation files by adding missing final newlines and updating config-flow copy to accurately describe available forms and fields.

Tests:
- Enable and stabilize reconfigure flow tests, including error scenarios, by adding deterministic cleanup of config entries.
- Add tests that compare English runtime config-flow keys against strings.json and verify that config flow strings describe the actual user and discovery_confirm steps.