### PR TITLE
Document setup, removal and troubleshooting; retire the stale info.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ To change the IP address or port of the ISG, use **Reconfigure** in the three-do
 menu of the integration entry. It leaves the entities untouched, so nothing has to be
 matched up afterwards.
 
+The domestic hot water circulation pump is a read-only operating status on
+WPMsystem and LWZ R290. It is therefore exposed as
+`binary_sensor.<device>_circulation_pump`, not as a switch. Existing
+automations and dashboards that reference the former switch entity need to use
+the binary sensor instead; switch actions must be removed because the register
+was never writable.
+
 For contributors, the transition the earlier migration notes described is complete.
 The compatibility shims are gone, along with `probe.py` and `client_bridge.py`:
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ To change the address later, open **Settings → Devices & services**, select th
 three-dot menu on the integration entry, and choose **Reconfigure**. Existing
 entity IDs and history are retained.
 
+## Energy and long-term statistics
+
+For the Energy Dashboard and other long-term statistics, use the cumulative
+consumed or produced energy sensor whose source combines the current day with
+the historical total (`day_and_total`). These sensors are marked as
+`total_increasing`, so Home Assistant can derive clean hourly and daily deltas
+from them.
+
+Sensors whose names end in **Today** expose the raw ISG day registers. They are
+useful on dashboards for the device's current-day value, but deliberately do
+not generate long-term sums. At midnight the ISG transfers only whole kWh to
+the total register and retains the fractional remainder in the day register.
+Treating that remainder as a reset to zero would count part of the energy
+twice.
+
+The separate **Total** sensors remain cumulative alternatives. Which energy
+entities are available depends on the connected controller.
+
 ## Removing the integration
 
 1. Open **Settings → Devices & services**.
@@ -102,6 +120,10 @@ history is retained by Home Assistant until it is deleted separately.
 The integration polls locally every 30 seconds. A failed update marks entities
 unavailable; it does not keep presenting cached values as current.
 Write errors are returned to the Home Assistant action that initiated them.
+
+The integration cannot update ISG firmware. Firmware updates are handled
+through Stiebel Eltron support. It also cannot make a register writable when
+the connected controller or firmware exposes it as read-only.
 
 ## Upgrading to 2026.7
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,31 @@
 
 [![Community Forum][forum-shield]][forum]
 
-## Preliminary Remark
-Although this integration has been created for Stiebel Eltron devices, it can successfully be used for Tecalor devices as well.
+## What this integration does
+
+This custom integration connects Home Assistant directly to an ISG over the
+local Modbus TCP interface. It does not require the Stiebel Eltron cloud or a
+Web-Monitoring subscription.
+
+Supported controller families include WPM 3, WPM 3i, WPMsystem, LWZ, LWZ x04
+SOL and LWZ R290. The exact entities depend on the controller and the registers
+it exposes. They can include temperatures, operating states, energy values,
+climate controls, setpoints, operating modes and SG Ready inputs.
+
+Although the integration was created for Stiebel Eltron devices, it can also be
+used with compatible Tecalor devices.
 
 ## Prerequisites
-In order to use this Integration you need:
 
-1. ISG device connected to the heat pump and your local network
-2. IP address of the ISG device on your local network
+You need:
+
+1. An ISG connected to the heat pump and the same local network as Home
+   Assistant.
+2. Modbus TCP enabled on the ISG.
+3. The IP address or hostname of the ISG. A DHCP reservation is recommended.
 
 For connecting the ISG device to your heat pump refer to the corresponding Stiebel Eltron documentation or ask your installer.
-There is no need to get the "STIEBEL ELTRON Web-Monitoring" subscription, this is for Stiebel Eltron itself monitoring your heat pump and NOT needed for this integration to work.
+There is no need to buy the "STIEBEL ELTRON Web-Monitoring" subscription.
 
 If you are using the ISG with the [STIEBEL ELTRON EMI extension](https://www.stiebel-eltron.de/de/home/service/smart-home/energy-management-interface-emi.html) make sure that your ISG Firmware is current because this Integration is using Modbus, older versions of ISG Software are not able to do Modbus and EMI at the same time. (ISG Software Version `v12.1.2` was tested by [@northalpha](https://github.com/northalpha) using this integration to be working).
 An update may be triggered via Stiebel Eltron Support (Kundendienst).
@@ -30,13 +44,15 @@ An update may be triggered via Stiebel Eltron Support (Kundendienst).
 
 ### Using HACS
 
+This is the preferred installation option:
 
-This is the preferred installation option. If you are using HACS:
-1. Add the component to your home assistant installation: [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=pail23&repository=stiebel_eltron_isg_component&category=integration)
-2. Add the _Stiebel Eltron ISG_ Integration in HACS and restart Home Assistant
-3. In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "Stiebel Eltron ISG"
+1. Open the repository in HACS: [![Open your Home Assistant instance and show
+   the HACS repository.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=pail23&repository=stiebel_eltron_isg_component&category=integration)
+2. Download _Stiebel Eltron ISG_ and restart Home Assistant.
+3. Go to **Settings → Devices & services**, select **Add integration**, and
+   search for _Stiebel Eltron ISG_.
 
-### Manual installation:
+### Manual installation
 
 1. Using the tool of choice open the directory (folder) for your HA configuration (where you find `configuration.yaml`).
 2. If you do not have a `custom_components` directory (folder) there, you need to create it.
@@ -44,14 +60,48 @@ This is the preferred installation option. If you are using HACS:
 4. Download _all_ the files from the `custom_components/stiebel_eltron_isg/` directory (folder) in this repository.
 5. Place the files you downloaded in the new directory (folder) you created.
 6. Restart Home Assistant
-7. In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "Stiebel Eltron ISG"
+7. Go to **Settings → Devices & services**, select **Add integration**, and
+   search for _Stiebel Eltron ISG_.
 
+## Configuration
 
+Configuration is entirely UI based. Enter the ISG host and Modbus TCP port
+(normally `502`). When the ISG advertises itself through DHCP, Home Assistant
+may discover it automatically.
 
+To change the address later, open **Settings → Devices & services**, select the
+three-dot menu on the integration entry, and choose **Reconfigure**. Existing
+entity IDs and history are retained.
 
-## Configuration is done in the UI
+## Removing the integration
 
-<!---->
+1. Open **Settings → Devices & services**.
+2. Select the three-dot menu on the Stiebel Eltron ISG entry and choose
+   **Delete**.
+3. To remove the code as well, uninstall the repository in HACS and restart
+   Home Assistant.
+
+Removing the entry stops polling and removes its devices and entities. Recorder
+history is retained by Home Assistant until it is deleted separately.
+
+## Troubleshooting
+
+- Verify that Home Assistant can reach the ISG on the configured host and port.
+- Confirm that Modbus TCP is enabled and that no firewall or VLAN rule blocks
+  the connection.
+- Reserve the ISG address in DHCP, or use **Reconfigure** after an address
+  change.
+- If the integration fails to start with _Unsupported controller model_,
+  include the controller ID from that error and the relevant Home Assistant log
+  in a GitHub issue.
+- For an entry that loads successfully, include a diagnostics download with the
+  issue. Diagnostics redact the configured host.
+- A register that is not exposed by a controller remains unavailable. This is
+  preferable to reporting a plausible but stale value.
+
+The integration polls locally every 30 seconds. A failed update marks entities
+unavailable; it does not keep presenting cached values as current.
+Write errors are returned to the Home Assistant action that initiated them.
 
 ## Upgrading to 2026.7
 
@@ -117,4 +167,3 @@ If you want to contribute to this please read the [Contribution guidelines](CONT
 [maintenance-shield]: https://img.shields.io/badge/maintainer-Paul%20Frank-green
 [releases-shield]: https://img.shields.io/github/v/release/pail23/stiebel_eltron_isg_component
 [releases]: https://github.com/pail23/stiebel_eltron_isg_component/releases
-

--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -21,7 +21,11 @@ from pystiebeleltron import (
 from .const import DEFAULT_PORT, UNIT_ID
 from .coordinator import StiebelEltronConfigEntry
 from .lwz_coordinator import StiebelEltronModbusLWZDataCoordinator
-from .migration import async_migrate_device_identifier, async_migrate_unique_ids
+from .migration import (
+    async_migrate_device_identifier,
+    async_migrate_unique_ids,
+    async_remove_legacy_circulation_pump_switch,
+)
 from .wpm3i_coordinator import StiebelEltronModbusWPM3iDataCoordinator
 from .wpm_coordinator import StiebelEltronModbusWPMDataCoordinator
 
@@ -75,6 +79,7 @@ async def async_setup_entry(
     # identifiers.
     async_migrate_device_identifier(hass, entry)
     await async_migrate_unique_ids(hass, entry, model)
+    async_remove_legacy_circulation_pump_switch(hass, entry)
 
     coordinator = None
 

--- a/custom_components/stiebel_eltron_isg/binary_sensor.py
+++ b/custom_components/stiebel_eltron_isg/binary_sensor.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
@@ -19,6 +20,7 @@ from .const import (
     BUFFER_4_CHARGING_PUMP,
     BUFFER_5_CHARGING_PUMP,
     BUFFER_6_CHARGING_PUMP,
+    CIRCULATION_PUMP,
     COMPRESSOR_ON,
     COOLING_MODE,
     DHW_CHARGING_PUMP,
@@ -405,6 +407,18 @@ WPM_BINARY_SENSOR_TYPES = [
     ),
 ]
 
+# Only WPMsystem and LWZ_R290 are confirmed to expose this system-state field,
+# see #607. Do not widen the model gate without controller-specific evidence.
+# pystiebeleltron exposes no matching writable WPM/LWZ parameter.
+CIRCULATION_PUMP_BINARY_SENSOR_TYPES = [
+    StiebelEltronBinarySensorEntityDescription(
+        key=CIRCULATION_PUMP,
+        translation_key=CIRCULATION_PUMP,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        modbus_register=lambda api: api.system_state.dhw_circulation_pump,
+    ),
+]
+
 
 LWZ_BINARY_SENSOR_TYPES = [
     StiebelEltronBinarySensorEntityDescription(
@@ -567,6 +581,17 @@ async def async_setup_entry(
             )
             for description in LWZ_BINARY_SENSOR_TYPES
         ]
+
+    if coordinator.model in (ControllerModel.LWZ_R290, ControllerModel.WPMsystem):
+        entities.extend(
+            StiebelEltronISGBinarySensor(
+                coordinator,
+                entry,
+                description,
+            )
+            for description in CIRCULATION_PUMP_BINARY_SENSOR_TYPES
+        )
+
     async_add_devices(entities)
 
 

--- a/custom_components/stiebel_eltron_isg/migration.py
+++ b/custom_components/stiebel_eltron_isg/migration.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from pystiebeleltron import ControllerModel
 
-from .const import DOMAIN, HEATER_PRESSURE
+from .const import CIRCULATION_PUMP, DOMAIN, HEATER_PRESSURE
 from .coordinator import StiebelEltronConfigEntry, coordinator_display_name
 from .entity import build_unique_id
 
@@ -31,6 +31,35 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 # entity would be migrated to an id that no entity description produces and stay
 # orphaned for the second time.
 _RENAMED_KEYS = {"heating_pressure": HEATER_PRESSURE}
+
+
+@callback
+def async_remove_legacy_circulation_pump_switch(
+    hass: HomeAssistant,
+    entry: StiebelEltronConfigEntry,
+) -> None:
+    """Remove the switch that represented a read-only status register."""
+    registry = er.async_get(hass)
+    obsolete = [
+        registry_entry
+        for registry_entry in er.async_entries_for_config_entry(
+            registry,
+            entry.entry_id,
+        )
+        if registry_entry.domain == "switch"
+        and (
+            registry_entry.unique_id == build_unique_id(entry, CIRCULATION_PUMP)
+            or registry_entry.unique_id.endswith(f"_{CIRCULATION_PUMP}")
+        )
+    ]
+    for registry_entry in obsolete:
+        registry.async_remove(registry_entry.entity_id)
+
+    if obsolete:
+        _LOGGER.info(
+            "Removed %s obsolete circulation pump switch entities",
+            len(obsolete),
+        )
 
 
 def _legacy_name(entry: StiebelEltronConfigEntry) -> str:

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -390,6 +390,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Circulation Pump"
+            },
             "pump_on_hk1": {
                 "name": "Pump HK1"
             },
@@ -657,9 +660,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready Input 2"
-            },
-            "circulation_pump": {
-                "name": "Circulation Pump"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/switch.py
+++ b/custom_components/stiebel_eltron_isg/switch.py
@@ -11,9 +11,8 @@ from homeassistant.components.switch import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pystiebeleltron import ControllerModel
 
-from .const import CIRCULATION_PUMP, SG_READY_ACTIVE, SG_READY_INPUT_1, SG_READY_INPUT_2
+from .const import SG_READY_ACTIVE, SG_READY_INPUT_1, SG_READY_INPUT_2
 from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
 from .entity import StiebelEltronISGEntity
 
@@ -67,18 +66,6 @@ SWITCH_TYPES = [
     ),
 ]
 
-# Only for controllers that expose a domestic hot water circulation pump.
-CIRCULATION_PUMP_SWITCH_TYPES = [
-    StiebelEltronSwitchEntityDescription(
-        key=CIRCULATION_PUMP,
-        translation_key=CIRCULATION_PUMP,
-        device_class=SwitchDeviceClass.SWITCH,
-        modbus_register=lambda api: api.system_state.dhw_circulation_pump,
-        write_component="system_state",
-        write_field="dhw_circulation_pump",
-    ),
-]
-
 
 async def async_setup_entry(
     _hass: HomeAssistant,
@@ -96,17 +83,6 @@ async def async_setup_entry(
         )
         for description in SWITCH_TYPES
     ]
-
-    if coordinator.model in (ControllerModel.LWZ_R290, ControllerModel.WPMsystem):
-        # Add the circulation pump switch for WPM systems
-        entities.extend(
-            StiebelEltronISGSwitch(
-                coordinator,
-                entry,
-                description,
-            )
-            for description in CIRCULATION_PUMP_SWITCH_TYPES
-        )
 
     async_add_devices(entities)
 
@@ -162,11 +138,7 @@ class StiebelEltronISGSwitch(StiebelEltronISGEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        if self.entity_description.key in (
-            CIRCULATION_PUMP,
-            SG_READY_INPUT_1,
-            SG_READY_INPUT_2,
-        ):
+        if self.entity_description.key in (SG_READY_INPUT_1, SG_READY_INPUT_2):
             # These writable switches stay operable even when the device does
             # not report a read-back value, but must still go unavailable when
             # the coordinator can no longer reach the device.

--- a/custom_components/stiebel_eltron_isg/translations/cz.json
+++ b/custom_components/stiebel_eltron_isg/translations/cz.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Cirkulační čerpadlo"
+            },
             "pump_on_hk1": {
                 "name": "Čerpadlo TO 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready vstup 2"
-            },
-            "circulation_pump": {
-                "name": "Cirkulační čerpadlo"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -390,6 +390,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Zirkulationspumpe"
+            },
             "pump_on_hk1": {
                 "name": "Pumpe HK 1"
             },
@@ -657,9 +660,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready Eingang 2"
-            },
-            "circulation_pump": {
-                "name": "Zirkulationspumpe"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -379,6 +379,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Circulation Pump"
+            },
             "pump_on_hk1": {
                 "name": "Pump HK1"
             },
@@ -646,9 +649,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready Input 2"
-            },
-            "circulation_pump": {
-                "name": "Circulation Pump"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/fr.json
+++ b/custom_components/stiebel_eltron_isg/translations/fr.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Pompe de circulation"
+            },
             "pump_on_hk1": {
                 "name": "Pompe CC 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready entrée 2"
-            },
-            "circulation_pump": {
-                "name": "Pompe de circulation"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/it.json
+++ b/custom_components/stiebel_eltron_isg/translations/it.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Pompa di circolazione"
+            },
             "pump_on_hk1": {
                 "name": "Pompa CC 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready ingresso 2"
-            },
-            "circulation_pump": {
-                "name": "Pompa di circolazione"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/pt.json
+++ b/custom_components/stiebel_eltron_isg/translations/pt.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Bomba de circulação"
+            },
             "pump_on_hk1": {
                 "name": "Bomba CC 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready entrada 2"
-            },
-            "circulation_pump": {
-                "name": "Bomba de circulação"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/sk.json
+++ b/custom_components/stiebel_eltron_isg/translations/sk.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Cirkulačné čerpadlo"
+            },
             "pump_on_hk1": {
                 "name": "Čerpadlo TO 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready vstup 2"
-            },
-            "circulation_pump": {
-                "name": "Cirkulačné čerpadlo"
             }
         },
         "button": {

--- a/info.md
+++ b/info.md
@@ -1,66 +1,14 @@
-# Stiebel Eltron ISG intergation with modus
+# Stiebel Eltron ISG integration
 
-[![GitHub Release][releases-shield]][releases]
-[![GitHub Activity][commits-shield]][commits]
-[![License][license-shield]](LICENSE)
+Connect Home Assistant directly to a Stiebel Eltron or compatible Tecalor ISG
+over local Modbus TCP. No cloud account or Web-Monitoring subscription is
+required.
 
-[![hacs][hacsbadge]][hacs]
-![Project Maintenance][maintenance-shield]
+The integration supports UI setup, DHCP discovery, reconfiguration and
+diagnostics. Available sensors and controls depend on the connected controller
+and the registers it exposes.
 
-[![Community Forum][forum-shield]][forum]
+For prerequisites, installation, configuration, removal, troubleshooting and
+upgrade notes, see the [complete documentation][documentation].
 
-_Component to integrate with [stiebel_eltron_isg][stiebel_eltron_isg]._
-
-**This component will set up the following platforms.**
-
-Platform | Description
--- | --
-`Produced Heating Today` | Produced energy for heating today.
-`Produced Heating Total` | Produced energy for heating in the lifetime of the heatpump.
-
-
-## Installation
-
-1. Using the tool of choice open the directory (folder) for your HA configuration (where you find `configuration.yaml`).
-2. If you do not have a `custom_components` directory (folder) there, you need to create it.
-3. In the `custom_components` directory (folder) create a new folder called `stiebel_eltron_isg`.
-4. Download _all_ the files from the `custom_components/stiebel_eltron_isg/` directory (folder) in this repository.
-5. Place the files you downloaded in the new directory (folder) you created.
-6. Restart Home Assistant
-7. In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "Stiebel Eltron ISG"
-
-Using your HA configuration directory (folder) as a starting point you should now also have this:
-
-```text
-custom_components/stiebel_eltron_isg/translations/en.json
-custom_components/stiebel_eltron_isg/translations/de.json
-custom_components/stiebel_eltron_isg/__init__.py
-custom_components/stiebel_eltron_isg/binary_sensor.py
-custom_components/stiebel_eltron_isg/config_flow.py
-custom_components/stiebel_eltron_isg/const.py
-custom_components/stiebel_eltron_isg/entity.py
-custom_components/stiebel_eltron_isg/manifest.json
-custom_components/stiebel_eltron_isg/sensor.py
-```
-
-## Configuration is done in the UI
-
-<!---->
-
-## Contributions are welcome!
-
-If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)
-
-***
-
-[stiebel_eltron_isg]: https://github.com/pail23/stiebel_eltron_isg
-[commits-shield]: https://img.shields.io/github/commit-activity/y/pail23/stiebel_eltron_isg_component
-[commits]: https://github.com/pail23/stiebel_eltron_isg/commits/master
-[hacs]: https://github.com/hacs
-[hacsbadge]: https://img.shields.io/badge/HACS-Custom-orange
-[forum-shield]: https://img.shields.io/badge/community-forum-brightgreen
-[forum]: https://community.home-assistant.io/
-[license-shield]: https://img.shields.io/github/license/pail23/stiebel_eltron_isg_component
-[maintenance-shield]: https://img.shields.io/badge/maintainer-Paul%20Frank-green
-[releases-shield]: https://img.shields.io/github/v/release/pail23/stiebel_eltron_isg_component
-[releases]: https://github.com/pail23/stiebel_eltron_isg/releases
+[documentation]: https://github.com/pail23/stiebel_eltron_isg_component#readme

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,73 @@
+"""Tests for the binary sensor platform."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from pystiebeleltron import ControllerModel
+import pytest
+
+from custom_components.stiebel_eltron_isg import binary_sensor
+from custom_components.stiebel_eltron_isg.const import CIRCULATION_PUMP
+from custom_components.stiebel_eltron_isg.switch import SWITCH_TYPES
+
+
+def test_circulation_pump_is_a_running_status() -> None:
+    """The read-only system-state register must be represented as a status."""
+    (description,) = binary_sensor.CIRCULATION_PUMP_BINARY_SENSOR_TYPES
+    api = SimpleNamespace(
+        system_state=SimpleNamespace(dhw_circulation_pump=1),
+    )
+
+    assert description.key == CIRCULATION_PUMP
+    assert description.device_class is BinarySensorDeviceClass.RUNNING
+    assert description.modbus_register(api) == 1
+    assert CIRCULATION_PUMP not in {description.key for description in SWITCH_TYPES}
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        (ControllerModel.WPMsystem, True),
+        (ControllerModel.LWZ_R290, True),
+        (ControllerModel.WPM_3, False),
+        (ControllerModel.LWZ, False),
+    ],
+)
+async def test_circulation_pump_is_only_added_for_supported_models(
+    model: ControllerModel,
+    expected: bool,
+) -> None:
+    """Only controllers exposing the register get the status entity."""
+    entry = SimpleNamespace(runtime_data=SimpleNamespace(model=model))
+    async_add_entities = MagicMock()
+
+    with patch.object(
+        binary_sensor,
+        "StiebelEltronISGBinarySensor",
+        side_effect=lambda _coordinator, _entry, description: description.key,
+    ):
+        await binary_sensor.async_setup_entry(None, entry, async_add_entities)
+
+    entities = async_add_entities.call_args.args[0]
+    assert (CIRCULATION_PUMP in entities) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, False), (0, False), (1, True)],
+)
+def test_circulation_pump_reports_the_read_back_state(value, expected: bool) -> None:
+    """The real entity maps the status register to an on/off state."""
+    (description,) = binary_sensor.CIRCULATION_PUMP_BINARY_SENSOR_TYPES
+    api = SimpleNamespace(
+        system_state=SimpleNamespace(dhw_circulation_pump=value),
+    )
+    entity = binary_sensor.StiebelEltronISGBinarySensor.__new__(
+        binary_sensor.StiebelEltronISGBinarySensor
+    )
+    entity.modbus_register = description.modbus_register
+    entity.bit_number = description.bit_number
+    entity.coordinator = SimpleNamespace(get_value=lambda accessor: accessor(api))
+
+    assert entity.is_on is expected

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -82,11 +82,15 @@ _DESCRIPTION_LISTS: list[tuple[str, str, list[Any]]] = [
     ("WPM_BINARY_SENSOR_TYPES", WPM, binary_sensor.WPM_BINARY_SENSOR_TYPES),
     ("WPM_3I_BINARY_SENSOR_TYPES", WPM_3I, binary_sensor.WPM_3I_BINARY_SENSOR_TYPES),
     ("LWZ_BINARY_SENSOR_TYPES", LWZ, binary_sensor.LWZ_BINARY_SENSOR_TYPES),
+    # WPMsystem and LWZ_R290, both of which are served by the WPM api.
+    (
+        "CIRCULATION_PUMP_BINARY_SENSOR_TYPES",
+        WPM,
+        binary_sensor.CIRCULATION_PUMP_BINARY_SENSOR_TYPES,
+    ),
     ("SWITCH_TYPES", WPM, switch.SWITCH_TYPES),
     ("SWITCH_TYPES", WPM_3I, switch.SWITCH_TYPES),
     ("SWITCH_TYPES", LWZ, switch.SWITCH_TYPES),
-    # WPMsystem and LWZ_R290, both of which are served by the WPM api.
-    ("CIRCULATION_PUMP_SWITCH_TYPES", WPM, switch.CIRCULATION_PUMP_SWITCH_TYPES),
     ("WPM_SELECT_TYPES", WPM, select.WPM_SELECT_TYPES),
     ("WPM_SELECT_TYPES", WPM_3I, select.WPM_SELECT_TYPES),
     ("LWZ_SELECT_TYPES", LWZ, select.LWZ_SELECT_TYPES),

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -8,7 +8,8 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.stiebel_eltron_isg import migration
-from custom_components.stiebel_eltron_isg.const import DOMAIN
+from custom_components.stiebel_eltron_isg.const import CIRCULATION_PUMP, DOMAIN
+from custom_components.stiebel_eltron_isg.entity import build_unique_id
 
 # The model the mock_get_controller_model fixture reports, and the display name
 # the coordinator derives from it.
@@ -45,6 +46,72 @@ def _register(
         config_entry=entry,
         suggested_object_id=object_id,
     )
+
+
+def test_removes_obsolete_circulation_pump_switch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """The domain change must not leave the old switch in the registry."""
+    mock_config_entry.add_to_hass(hass)
+    obsolete = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(mock_config_entry, CIRCULATION_PUMP),
+        "circulation_pump",
+        domain="switch",
+    )
+
+    migration.async_remove_legacy_circulation_pump_switch(hass, mock_config_entry)
+
+    assert er.async_get(hass).async_get(obsolete.entity_id) is None
+
+
+def test_circulation_pump_cleanup_leaves_other_switches_untouched(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Only the obsolete entity with the exact unique id is removed."""
+    mock_config_entry.add_to_hass(hass)
+    other = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(mock_config_entry, "sg_ready_active"),
+        "sg_ready_active",
+        domain="switch",
+    )
+
+    migration.async_remove_legacy_circulation_pump_switch(hass, mock_config_entry)
+
+    assert er.async_get(hass).async_get(other.entity_id) is not None
+
+
+def test_removes_legacy_duplicate_circulation_pump_switches(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A duplicate left on either historical unique-id scheme is removed."""
+    mock_config_entry.add_to_hass(hass)
+    current = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(mock_config_entry, CIRCULATION_PUMP),
+        "circulation_pump",
+        domain="switch",
+    )
+    legacy = _register(
+        hass,
+        mock_config_entry,
+        f"{DOMAIN}_Stiebel Eltron_{CIRCULATION_PUMP}",
+        "legacy_circulation_pump",
+        domain="switch",
+    )
+
+    migration.async_remove_legacy_circulation_pump_switch(hass, mock_config_entry)
+
+    registry = er.async_get(hass)
+    assert registry.async_get(current.entity_id) is None
+    assert registry.async_get(legacy.entity_id) is None
 
 
 async def test_migrates_entities_of_the_configured_name_scheme(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 
-from custom_components.stiebel_eltron_isg.const import CIRCULATION_PUMP
+from custom_components.stiebel_eltron_isg.const import SG_READY_INPUT_1
 from custom_components.stiebel_eltron_isg.switch import StiebelEltronISGSwitch
 
 
@@ -13,15 +13,15 @@ def _make_switch(key: str, last_update_success: bool) -> StiebelEltronISGSwitch:
     return entity
 
 
-def test_circulation_pump_switch_unavailable_when_last_update_failed() -> None:
-    """The always-on switches must still go unavailable on a failed update."""
-    entity = _make_switch(CIRCULATION_PUMP, last_update_success=False)
+def test_write_only_switch_unavailable_when_last_update_failed() -> None:
+    """A write-only switch must still go unavailable on a failed update."""
+    entity = _make_switch(SG_READY_INPUT_1, last_update_success=False)
 
     assert entity.available is False
 
 
-def test_circulation_pump_switch_available_when_update_succeeded() -> None:
-    """With a successful update the switch stays available."""
-    entity = _make_switch(CIRCULATION_PUMP, last_update_success=True)
+def test_write_only_switch_available_when_update_succeeded() -> None:
+    """With a successful update a write-only switch stays available."""
+    entity = _make_switch(SG_READY_INPUT_1, last_update_success=True)
 
     assert entity.available is True


### PR DESCRIPTION
Depends on the circulation pump fix and is based on that branch, because it keeps
the upgrade note that PR adds. Please merge the circulation pump PR first.

The README told users to click "Configuration -> Integrations" and never
explained what the integration actually is, what it needs, or how to remove it.
`info.md`, which is what HACS shows before installation, listed two sensors and a
file layout from several releases ago.

## Changes

`README.md`

- New opening section: local Modbus TCP, no cloud and no Web-Monitoring
  subscription, the supported controller families, and the fact that the actual
  entities depend on the controller and the registers it serves.
- Prerequisites now name all three: the ISG on the same network, Modbus TCP
  enabled, and the address, with a DHCP reservation recommended.
- Installation and setup use the current Home Assistant paths.
- New Configuration section covering host and port, DHCP discovery, and
  Reconfigure as the way to change the address without losing entity IDs and
  history.
- New Removing the integration section, including that recorder history stays
  until it is deleted separately.
- New Troubleshooting section: reachability, Modbus enabled, firewall and VLAN,
  what to attach for an "Unsupported controller model" error, diagnostics for an
  entry that loads, and why an unserved register stays unavailable instead of
  showing a stale value. It also states the 30 second poll and that failed
  updates mark entities unavailable rather than presenting cached values.

`info.md`

- Reduced to what a HACS listing needs: what the integration does, that setup,
  discovery, reconfiguration and diagnostics exist, and a link to the README.
  Duplicating the installation instructions is what let it go stale.

Documentation only. No code, no behavior and no dependency changes.
Part of #629.

## Summary by Sourcery

Improve documentation for setup, configuration, removal and troubleshooting of the Stiebel Eltron ISG Home Assistant integration, and correct the handling of the domestic hot water circulation pump by representing it as a read-only status binary sensor instead of a writable switch.

Enhancements:
- Expose the domestic hot water circulation pump as a running-status binary sensor for supported controllers and stop exposing it as a writable switch.
- Add a migration step that removes legacy circulation pump switch entities from the registry while leaving other switches untouched.

Documentation:
- Expand README with clear description of the integration, prerequisites, installation paths, configuration, removal, troubleshooting guidance, and updated upgrade notes.
- Trim info.md to a concise HACS listing that points to the main README for complete documentation.

Tests:
- Add and update tests to cover circulation pump behavior as a binary sensor, ensure it is only exposed for supported controller models, and verify cleanup of obsolete switch entities.
- Adjust switch availability tests to focus on write-only SG Ready inputs rather than the removed circulation pump switch.