### PR TITLE
Enforce coverage for every integration module in CI

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -82,6 +82,11 @@ jobs:
             --durations=10 \
             -n auto \
             --cov custom_components.stiebel_eltron_isg \
+            --cov-report=json:coverage.json \
+            --cov-report=term-missing:skip-covered \
             -o console_output_style=count \
             -p no:sugar \
             tests
+      - name: Enforce per-module coverage
+        if: always()
+        run: uv run --prerelease=allow python scripts/check_module_coverage.py coverage.json --target 95

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ venv
 .coverage
 .vscode
 coverage.xml
+coverage.json
 .ruff_cache
 .mypy_cache
 .pytest_cache

--- a/scripts/check_module_coverage.py
+++ b/scripts/check_module_coverage.py
@@ -1,0 +1,48 @@
+"""Fail unless every integration module exceeds the coverage target."""
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+INTEGRATION_PREFIX = "custom_components/stiebel_eltron_isg/"
+
+
+def modules_failing_target(report: dict, target: float) -> list[tuple[str, float]]:
+    """Return integration modules that do not exceed target."""
+    modules = sorted(
+        (filename, details["summary"]["percent_covered"])
+        for filename, details in report["files"].items()
+        if filename.startswith(INTEGRATION_PREFIX)
+    )
+    if not modules:
+        raise ValueError(
+            f"coverage report contains no files below {INTEGRATION_PREFIX}"
+        )
+    return [
+        (filename, coverage) for filename, coverage in modules if coverage <= target
+    ]
+
+
+def main() -> int:
+    """Check a coverage.py JSON report."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("report", type=Path)
+    parser.add_argument("--target", type=float, default=95)
+    args = parser.parse_args()
+    try:
+        report = json.loads(args.report.read_text(encoding="utf-8"))
+        failures = modules_failing_target(report, args.target)
+    except (OSError, KeyError, TypeError, ValueError) as err:
+        print(f"Cannot check module coverage: {err}", file=sys.stderr)  # noqa: T201
+        return 1
+
+    for filename, coverage in failures:
+        print(  # noqa: T201
+            f"{filename}: {coverage:.2f}% (required: more than {args.target:.2f}%)"
+        )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_module_coverage.py
+++ b/scripts/check_module_coverage.py
@@ -17,7 +17,7 @@ def modules_failing_target(report: dict, target: float) -> list[tuple[str, float
     )
     if not modules:
         raise ValueError(
-            f"coverage report contains no files below {INTEGRATION_PREFIX}"
+            f"coverage report contains no files with prefix {INTEGRATION_PREFIX}"
         )
     return [
         (filename, coverage) for filename, coverage in modules if coverage <= target
@@ -34,7 +34,10 @@ def main() -> int:
         report = json.loads(args.report.read_text(encoding="utf-8"))
         failures = modules_failing_target(report, args.target)
     except (OSError, KeyError, TypeError, ValueError) as err:
-        print(f"Cannot check module coverage: {err}", file=sys.stderr)  # noqa: T201
+        print(  # noqa: T201
+            f"Cannot check module coverage for {args.report}: {err}",
+            file=sys.stderr,
+        )
         return 1
 
     for filename, coverage in failures:

--- a/tests/test_module_coverage.py
+++ b/tests/test_module_coverage.py
@@ -1,0 +1,62 @@
+"""Tests for the per-module coverage gate."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "check_module_coverage.py"
+_SPEC = importlib.util.spec_from_file_location("check_module_coverage", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def test_only_integration_modules_not_above_target_are_reported() -> None:
+    """External files are ignored and the strict boundary is enforced."""
+    report = {
+        "files": {
+            "custom_components/stiebel_eltron_isg/good.py": {
+                "summary": {"percent_covered": 95.01}
+            },
+            "custom_components/stiebel_eltron_isg/exact.py": {
+                "summary": {"percent_covered": 95.0}
+            },
+            "custom_components/stiebel_eltron_isg/low.py": {
+                "summary": {"percent_covered": 94.99}
+            },
+            "tests/test_example.py": {"summary": {"percent_covered": 0.0}},
+        }
+    }
+
+    assert _MODULE.modules_failing_target(report, 95) == [
+        ("custom_components/stiebel_eltron_isg/exact.py", 95.0),
+        ("custom_components/stiebel_eltron_isg/low.py", 94.99),
+    ]
+
+
+def test_empty_integration_match_fails_closed() -> None:
+    """A path or report-format change must not turn the gate green."""
+    report = {
+        "files": {"tests/test_example.py": {"summary": {"percent_covered": 100.0}}}
+    }
+
+    with pytest.raises(ValueError, match="contains no files"):
+        _MODULE.modules_failing_target(report, 95)
+
+
+def test_main_fails_closed_for_missing_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The command exits non-zero and explains an unreadable report."""
+    report = tmp_path / "missing.json"
+    monkeypatch.setattr(
+        _MODULE.sys,
+        "argv",
+        ["check_module_coverage.py", str(report)],
+    )
+
+    assert _MODULE.main() == 1
+    assert "Cannot check module coverage" in capsys.readouterr().err

--- a/tests/test_module_coverage.py
+++ b/tests/test_module_coverage.py
@@ -7,7 +7,8 @@ import pytest
 
 _SCRIPT = Path(__file__).parents[1] / "scripts" / "check_module_coverage.py"
 _SPEC = importlib.util.spec_from_file_location("check_module_coverage", _SCRIPT)
-assert _SPEC is not None and _SPEC.loader is not None
+assert _SPEC is not None
+assert _SPEC.loader is not None
 _MODULE = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_MODULE)
 

--- a/tests/test_module_coverage.py
+++ b/tests/test_module_coverage.py
@@ -1,6 +1,7 @@
 """Tests for the per-module coverage gate."""
 
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -42,7 +43,7 @@ def test_empty_integration_match_fails_closed() -> None:
         "files": {"tests/test_example.py": {"summary": {"percent_covered": 100.0}}}
     }
 
-    with pytest.raises(ValueError, match="contains no files"):
+    with pytest.raises(ValueError, match="contains no files with prefix"):
         _MODULE.modules_failing_target(report, 95)
 
 
@@ -60,4 +61,74 @@ def test_main_fails_closed_for_missing_report(
     )
 
     assert _MODULE.main() == 1
-    assert "Cannot check module coverage" in capsys.readouterr().err
+    assert f"Cannot check module coverage for {report}:" in capsys.readouterr().err
+
+
+def test_main_accepts_a_readable_report_above_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The command succeeds silently when every integration module passes."""
+    report = tmp_path / "coverage.json"
+    report.write_text(
+        json.dumps({
+            "files": {
+                "custom_components/stiebel_eltron_isg/good.py": {
+                    "summary": {"percent_covered": 95.01}
+                }
+            }
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        _MODULE.sys,
+        "argv",
+        ["check_module_coverage.py", str(report)],
+    )
+
+    assert _MODULE.main() == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_main_reports_every_module_not_above_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The command exits non-zero with actionable lines for failing modules."""
+    report = tmp_path / "coverage.json"
+    report.write_text(
+        json.dumps({
+            "files": {
+                "custom_components/stiebel_eltron_isg/exact.py": {
+                    "summary": {"percent_covered": 95.0}
+                },
+                "custom_components/stiebel_eltron_isg/low.py": {
+                    "summary": {"percent_covered": 94.99}
+                },
+            }
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        _MODULE.sys,
+        "argv",
+        ["check_module_coverage.py", str(report)],
+    )
+
+    assert _MODULE.main() == 1
+    captured = capsys.readouterr()
+    assert captured.out.splitlines() == [
+        (
+            "custom_components/stiebel_eltron_isg/exact.py: 95.00% "
+            "(required: more than 95.00%)"
+        ),
+        (
+            "custom_components/stiebel_eltron_isg/low.py: 94.99% "
+            "(required: more than 95.00%)"
+        ),
+    ]
+    assert captured.err == ""


### PR DESCRIPTION
CI collected coverage but never failed on it, and an aggregate number hides
individual modules: a well-covered `const.py` can carry a barely covered
platform. The Quality Scale asks for more than 95% per module, so that is what
the gate checks.

## Changes

- `scripts/check_module_coverage.py` reads the coverage.py JSON report and fails
  when any file under `custom_components/stiebel_eltron_isg/` is at or below the
  target. Exactly 95.00% fails; the rule is "more than". It fails closed: if the
  report contains no file under that prefix at all, for example after a path or
  report-format change, the script errors instead of reporting success.
- `lint_test.yml` writes `coverage.json` alongside a term-missing report and runs
  the check with `--target 95`, with `if: always()` so a failing gate is visible
  even when something else in the job fails.
- `.gitignore`: `coverage.json`.

## Tests

- Only integration modules are reported, external files are ignored, and the
  strict boundary is asserted at 95.01, 95.00 and 94.99.
- An empty integration match raises instead of passing.
- `main` exits non-zero and explains itself for an unreadable report.

## Merge order

This PR must be merged last. Enforcement only makes sense once the coverage work
is in, and it is intentionally order-dependent: merged early, it turns the
pipeline red for every unrelated PR.

It therefore remains a draft for now and should only be marked ready for review
after the other PRs in this batch have been merged.

With the config-flow, coordinator/setup, writable-platform and read-only-platform
coverage PRs plus the circulation pump fix and #592 integrated, the full suite
runs 674 passed, 0 skipped at 99% total coverage, with every integration module
strictly above 95%, and the gate, Ruff, the format check and the diff check are
green. That is the integrated result, not the result of any single PR in the
series.

No dependency changes; the gate uses the coverage report the job already
produces.
Part of #629.

## Summary by Sourcery

Enforce a strict per-module coverage gate for the stiebel_eltron_isg integration based on the coverage.py JSON report.

Enhancements:
- Add a script that parses coverage.json and fails when any integration module is at or below a configurable coverage target, failing closed when the report is unreadable or lacks integration files.

Build:
- Ignore coverage.json in version control.

CI:
- Extend the lint_test workflow to emit a JSON and term-missing coverage report and always run the per-module coverage gate with a 95% threshold.

Tests:
- Add tests validating that only integration modules are checked, that the coverage threshold is enforced precisely, and that missing or incompatible reports cause the gate to fail with an explanatory error.