### PR TITLE
Cover read-only entity behavior for sensor and binary sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ To change the IP address or port of the ISG, use **Reconfigure** in the three-do
 menu of the integration entry. It leaves the entities untouched, so nothing has to be
 matched up afterwards.
 
+The domestic hot water circulation pump is a read-only operating status on
+WPMsystem and LWZ R290. It is therefore exposed as
+`binary_sensor.<device>_circulation_pump`, not as a switch. Existing
+automations and dashboards that reference the former switch entity need to use
+the binary sensor instead; switch actions must be removed because the register
+was never writable.
+
 For contributors, the transition the earlier migration notes described is complete.
 The compatibility shims are gone, along with `probe.py` and `client_bridge.py`:
 

--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -21,7 +21,11 @@ from pystiebeleltron import (
 from .const import DEFAULT_PORT, UNIT_ID
 from .coordinator import StiebelEltronConfigEntry
 from .lwz_coordinator import StiebelEltronModbusLWZDataCoordinator
-from .migration import async_migrate_device_identifier, async_migrate_unique_ids
+from .migration import (
+    async_migrate_device_identifier,
+    async_migrate_unique_ids,
+    async_remove_legacy_circulation_pump_switch,
+)
 from .wpm3i_coordinator import StiebelEltronModbusWPM3iDataCoordinator
 from .wpm_coordinator import StiebelEltronModbusWPMDataCoordinator
 
@@ -75,6 +79,7 @@ async def async_setup_entry(
     # identifiers.
     async_migrate_device_identifier(hass, entry)
     await async_migrate_unique_ids(hass, entry, model)
+    async_remove_legacy_circulation_pump_switch(hass, entry)
 
     coordinator = None
 

--- a/custom_components/stiebel_eltron_isg/binary_sensor.py
+++ b/custom_components/stiebel_eltron_isg/binary_sensor.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
@@ -19,6 +20,7 @@ from .const import (
     BUFFER_4_CHARGING_PUMP,
     BUFFER_5_CHARGING_PUMP,
     BUFFER_6_CHARGING_PUMP,
+    CIRCULATION_PUMP,
     COMPRESSOR_ON,
     COOLING_MODE,
     DHW_CHARGING_PUMP,
@@ -405,6 +407,18 @@ WPM_BINARY_SENSOR_TYPES = [
     ),
 ]
 
+# Only WPMsystem and LWZ_R290 are confirmed to expose this system-state field,
+# see #607. Do not widen the model gate without controller-specific evidence.
+# pystiebeleltron exposes no matching writable WPM/LWZ parameter.
+CIRCULATION_PUMP_BINARY_SENSOR_TYPES = [
+    StiebelEltronBinarySensorEntityDescription(
+        key=CIRCULATION_PUMP,
+        translation_key=CIRCULATION_PUMP,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        modbus_register=lambda api: api.system_state.dhw_circulation_pump,
+    ),
+]
+
 
 LWZ_BINARY_SENSOR_TYPES = [
     StiebelEltronBinarySensorEntityDescription(
@@ -567,6 +581,17 @@ async def async_setup_entry(
             )
             for description in LWZ_BINARY_SENSOR_TYPES
         ]
+
+    if coordinator.model in (ControllerModel.LWZ_R290, ControllerModel.WPMsystem):
+        entities.extend(
+            StiebelEltronISGBinarySensor(
+                coordinator,
+                entry,
+                description,
+            )
+            for description in CIRCULATION_PUMP_BINARY_SENSOR_TYPES
+        )
+
     async_add_devices(entities)
 
 

--- a/custom_components/stiebel_eltron_isg/migration.py
+++ b/custom_components/stiebel_eltron_isg/migration.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from pystiebeleltron import ControllerModel
 
-from .const import DOMAIN, HEATER_PRESSURE
+from .const import CIRCULATION_PUMP, DOMAIN, HEATER_PRESSURE
 from .coordinator import StiebelEltronConfigEntry, coordinator_display_name
 from .entity import build_unique_id
 
@@ -31,6 +31,35 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 # entity would be migrated to an id that no entity description produces and stay
 # orphaned for the second time.
 _RENAMED_KEYS = {"heating_pressure": HEATER_PRESSURE}
+
+
+@callback
+def async_remove_legacy_circulation_pump_switch(
+    hass: HomeAssistant,
+    entry: StiebelEltronConfigEntry,
+) -> None:
+    """Remove the switch that represented a read-only status register."""
+    registry = er.async_get(hass)
+    obsolete = [
+        registry_entry
+        for registry_entry in er.async_entries_for_config_entry(
+            registry,
+            entry.entry_id,
+        )
+        if registry_entry.domain == "switch"
+        and (
+            registry_entry.unique_id == build_unique_id(entry, CIRCULATION_PUMP)
+            or registry_entry.unique_id.endswith(f"_{CIRCULATION_PUMP}")
+        )
+    ]
+    for registry_entry in obsolete:
+        registry.async_remove(registry_entry.entity_id)
+
+    if obsolete:
+        _LOGGER.info(
+            "Removed %s obsolete circulation pump switch entities",
+            len(obsolete),
+        )
 
 
 def _legacy_name(entry: StiebelEltronConfigEntry) -> str:

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -390,6 +390,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Circulation Pump"
+            },
             "pump_on_hk1": {
                 "name": "Pump HK1"
             },
@@ -657,9 +660,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready Input 2"
-            },
-            "circulation_pump": {
-                "name": "Circulation Pump"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/switch.py
+++ b/custom_components/stiebel_eltron_isg/switch.py
@@ -11,9 +11,8 @@ from homeassistant.components.switch import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pystiebeleltron import ControllerModel
 
-from .const import CIRCULATION_PUMP, SG_READY_ACTIVE, SG_READY_INPUT_1, SG_READY_INPUT_2
+from .const import SG_READY_ACTIVE, SG_READY_INPUT_1, SG_READY_INPUT_2
 from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
 from .entity import StiebelEltronISGEntity
 
@@ -67,18 +66,6 @@ SWITCH_TYPES = [
     ),
 ]
 
-# Only for controllers that expose a domestic hot water circulation pump.
-CIRCULATION_PUMP_SWITCH_TYPES = [
-    StiebelEltronSwitchEntityDescription(
-        key=CIRCULATION_PUMP,
-        translation_key=CIRCULATION_PUMP,
-        device_class=SwitchDeviceClass.SWITCH,
-        modbus_register=lambda api: api.system_state.dhw_circulation_pump,
-        write_component="system_state",
-        write_field="dhw_circulation_pump",
-    ),
-]
-
 
 async def async_setup_entry(
     _hass: HomeAssistant,
@@ -96,17 +83,6 @@ async def async_setup_entry(
         )
         for description in SWITCH_TYPES
     ]
-
-    if coordinator.model in (ControllerModel.LWZ_R290, ControllerModel.WPMsystem):
-        # Add the circulation pump switch for WPM systems
-        entities.extend(
-            StiebelEltronISGSwitch(
-                coordinator,
-                entry,
-                description,
-            )
-            for description in CIRCULATION_PUMP_SWITCH_TYPES
-        )
 
     async_add_devices(entities)
 
@@ -162,11 +138,7 @@ class StiebelEltronISGSwitch(StiebelEltronISGEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        if self.entity_description.key in (
-            CIRCULATION_PUMP,
-            SG_READY_INPUT_1,
-            SG_READY_INPUT_2,
-        ):
+        if self.entity_description.key in (SG_READY_INPUT_1, SG_READY_INPUT_2):
             # These writable switches stay operable even when the device does
             # not report a read-back value, but must still go unavailable when
             # the coordinator can no longer reach the device.

--- a/custom_components/stiebel_eltron_isg/translations/cz.json
+++ b/custom_components/stiebel_eltron_isg/translations/cz.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Cirkulační čerpadlo"
+            },
             "pump_on_hk1": {
                 "name": "Čerpadlo TO 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready vstup 2"
-            },
-            "circulation_pump": {
-                "name": "Cirkulační čerpadlo"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -390,6 +390,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Zirkulationspumpe"
+            },
             "pump_on_hk1": {
                 "name": "Pumpe HK 1"
             },
@@ -657,9 +660,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready Eingang 2"
-            },
-            "circulation_pump": {
-                "name": "Zirkulationspumpe"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -379,6 +379,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Circulation Pump"
+            },
             "pump_on_hk1": {
                 "name": "Pump HK1"
             },
@@ -646,9 +649,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready Input 2"
-            },
-            "circulation_pump": {
-                "name": "Circulation Pump"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/fr.json
+++ b/custom_components/stiebel_eltron_isg/translations/fr.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Pompe de circulation"
+            },
             "pump_on_hk1": {
                 "name": "Pompe CC 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready entrée 2"
-            },
-            "circulation_pump": {
-                "name": "Pompe de circulation"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/it.json
+++ b/custom_components/stiebel_eltron_isg/translations/it.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Pompa di circolazione"
+            },
             "pump_on_hk1": {
                 "name": "Pompa CC 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready ingresso 2"
-            },
-            "circulation_pump": {
-                "name": "Pompa di circolazione"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/pt.json
+++ b/custom_components/stiebel_eltron_isg/translations/pt.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Bomba de circulação"
+            },
             "pump_on_hk1": {
                 "name": "Bomba CC 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready entrada 2"
-            },
-            "circulation_pump": {
-                "name": "Bomba de circulação"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/sk.json
+++ b/custom_components/stiebel_eltron_isg/translations/sk.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Cirkulačné čerpadlo"
+            },
             "pump_on_hk1": {
                 "name": "Čerpadlo TO 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready vstup 2"
-            },
-            "circulation_pump": {
-                "name": "Cirkulačné čerpadlo"
             }
         },
         "button": {

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,73 @@
+"""Tests for the binary sensor platform."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from pystiebeleltron import ControllerModel
+import pytest
+
+from custom_components.stiebel_eltron_isg import binary_sensor
+from custom_components.stiebel_eltron_isg.const import CIRCULATION_PUMP
+from custom_components.stiebel_eltron_isg.switch import SWITCH_TYPES
+
+
+def test_circulation_pump_is_a_running_status() -> None:
+    """The read-only system-state register must be represented as a status."""
+    (description,) = binary_sensor.CIRCULATION_PUMP_BINARY_SENSOR_TYPES
+    api = SimpleNamespace(
+        system_state=SimpleNamespace(dhw_circulation_pump=1),
+    )
+
+    assert description.key == CIRCULATION_PUMP
+    assert description.device_class is BinarySensorDeviceClass.RUNNING
+    assert description.modbus_register(api) == 1
+    assert CIRCULATION_PUMP not in {description.key for description in SWITCH_TYPES}
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        (ControllerModel.WPMsystem, True),
+        (ControllerModel.LWZ_R290, True),
+        (ControllerModel.WPM_3, False),
+        (ControllerModel.LWZ, False),
+    ],
+)
+async def test_circulation_pump_is_only_added_for_supported_models(
+    model: ControllerModel,
+    expected: bool,
+) -> None:
+    """Only controllers exposing the register get the status entity."""
+    entry = SimpleNamespace(runtime_data=SimpleNamespace(model=model))
+    async_add_entities = MagicMock()
+
+    with patch.object(
+        binary_sensor,
+        "StiebelEltronISGBinarySensor",
+        side_effect=lambda _coordinator, _entry, description: description.key,
+    ):
+        await binary_sensor.async_setup_entry(None, entry, async_add_entities)
+
+    entities = async_add_entities.call_args.args[0]
+    assert (CIRCULATION_PUMP in entities) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, False), (0, False), (1, True)],
+)
+def test_circulation_pump_reports_the_read_back_state(value, expected: bool) -> None:
+    """The real entity maps the status register to an on/off state."""
+    (description,) = binary_sensor.CIRCULATION_PUMP_BINARY_SENSOR_TYPES
+    api = SimpleNamespace(
+        system_state=SimpleNamespace(dhw_circulation_pump=value),
+    )
+    entity = binary_sensor.StiebelEltronISGBinarySensor.__new__(
+        binary_sensor.StiebelEltronISGBinarySensor
+    )
+    entity.modbus_register = description.modbus_register
+    entity.bit_number = description.bit_number
+    entity.coordinator = SimpleNamespace(get_value=lambda accessor: accessor(api))
+
+    assert entity.is_on is expected

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -31,6 +31,7 @@ def test_circulation_pump_is_a_running_status() -> None:
         (ControllerModel.WPMsystem, True),
         (ControllerModel.LWZ_R290, True),
         (ControllerModel.WPM_3, False),
+        (ControllerModel.WPM_3i, False),
         (ControllerModel.LWZ, False),
     ],
 )
@@ -69,5 +70,31 @@ def test_circulation_pump_reports_the_read_back_state(value, expected: bool) -> 
     entity.modbus_register = description.modbus_register
     entity.bit_number = description.bit_number
     entity.coordinator = SimpleNamespace(get_value=lambda accessor: accessor(api))
+
+    assert entity.is_on is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "bit_number", "expected"),
+    [
+        (None, 0, False),
+        (0, 0, False),
+        (1, 0, True),
+        (2, 0, False),
+        (2, 1, True),
+    ],
+)
+def test_binary_sensor_reads_its_configured_bit(
+    value,
+    bit_number: int,
+    expected: bool,
+) -> None:
+    """Binary sensors handle missing values and packed status bits."""
+    entity = binary_sensor.StiebelEltronISGBinarySensor.__new__(
+        binary_sensor.StiebelEltronISGBinarySensor
+    )
+    entity.modbus_register = lambda api: None
+    entity.bit_number = bit_number
+    entity.coordinator = SimpleNamespace(get_value=lambda accessor: value)
 
     assert entity.is_on is expected

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from modbus_connection import ModbusError
-from pystiebeleltron import StiebelEltronModbusError
+from pystiebeleltron import ControllerModel, StiebelEltronModbusError
 import pytest
 
 from custom_components.stiebel_eltron_isg.const import DOMAIN
@@ -14,6 +14,9 @@ from custom_components.stiebel_eltron_isg.coordinator import (
 )
 from custom_components.stiebel_eltron_isg.lwz_coordinator import (
     StiebelEltronModbusLWZDataCoordinator,
+)
+from custom_components.stiebel_eltron_isg.wpm3i_coordinator import (
+    StiebelEltronModbusWPM3iDataCoordinator,
 )
 
 
@@ -192,3 +195,23 @@ async def test_lwz_reset_heatpump_uses_central_write_path() -> None:
     coordinator.write_component_value.assert_awaited_once_with(
         "system_parameters", "reset", 1
     )
+
+
+def test_wpm_3i_coordinator_initializes_model_specific_api(
+    hass,
+    mock_config_entry,
+    mock_modbus_connection,
+    mock_wpm_3i_api,
+) -> None:
+    """The WPM 3i coordinator keeps its model-specific API, model and host."""
+    coordinator = StiebelEltronModbusWPM3iDataCoordinator(
+        hass,
+        mock_config_entry,
+        ControllerModel.WPM_3i,
+        mock_modbus_connection,
+        "isg.local",
+    )
+
+    assert coordinator.model is ControllerModel.WPM_3i
+    assert coordinator.host == "isg.local"
+    assert coordinator._api is mock_wpm_3i_api

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -82,11 +82,15 @@ _DESCRIPTION_LISTS: list[tuple[str, str, list[Any]]] = [
     ("WPM_BINARY_SENSOR_TYPES", WPM, binary_sensor.WPM_BINARY_SENSOR_TYPES),
     ("WPM_3I_BINARY_SENSOR_TYPES", WPM_3I, binary_sensor.WPM_3I_BINARY_SENSOR_TYPES),
     ("LWZ_BINARY_SENSOR_TYPES", LWZ, binary_sensor.LWZ_BINARY_SENSOR_TYPES),
+    # WPMsystem and LWZ_R290, both of which are served by the WPM api.
+    (
+        "CIRCULATION_PUMP_BINARY_SENSOR_TYPES",
+        WPM,
+        binary_sensor.CIRCULATION_PUMP_BINARY_SENSOR_TYPES,
+    ),
     ("SWITCH_TYPES", WPM, switch.SWITCH_TYPES),
     ("SWITCH_TYPES", WPM_3I, switch.SWITCH_TYPES),
     ("SWITCH_TYPES", LWZ, switch.SWITCH_TYPES),
-    # WPMsystem and LWZ_R290, both of which are served by the WPM api.
-    ("CIRCULATION_PUMP_SWITCH_TYPES", WPM, switch.CIRCULATION_PUMP_SWITCH_TYPES),
     ("WPM_SELECT_TYPES", WPM, select.WPM_SELECT_TYPES),
     ("WPM_SELECT_TYPES", WPM_3I, select.WPM_SELECT_TYPES),
     ("LWZ_SELECT_TYPES", LWZ, select.LWZ_SELECT_TYPES),

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -8,7 +8,8 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.stiebel_eltron_isg import migration
-from custom_components.stiebel_eltron_isg.const import DOMAIN
+from custom_components.stiebel_eltron_isg.const import CIRCULATION_PUMP, DOMAIN
+from custom_components.stiebel_eltron_isg.entity import build_unique_id
 
 # The model the mock_get_controller_model fixture reports, and the display name
 # the coordinator derives from it.
@@ -45,6 +46,72 @@ def _register(
         config_entry=entry,
         suggested_object_id=object_id,
     )
+
+
+def test_removes_obsolete_circulation_pump_switch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """The domain change must not leave the old switch in the registry."""
+    mock_config_entry.add_to_hass(hass)
+    obsolete = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(mock_config_entry, CIRCULATION_PUMP),
+        "circulation_pump",
+        domain="switch",
+    )
+
+    migration.async_remove_legacy_circulation_pump_switch(hass, mock_config_entry)
+
+    assert er.async_get(hass).async_get(obsolete.entity_id) is None
+
+
+def test_circulation_pump_cleanup_leaves_other_switches_untouched(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Only the obsolete entity with the exact unique id is removed."""
+    mock_config_entry.add_to_hass(hass)
+    other = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(mock_config_entry, "sg_ready_active"),
+        "sg_ready_active",
+        domain="switch",
+    )
+
+    migration.async_remove_legacy_circulation_pump_switch(hass, mock_config_entry)
+
+    assert er.async_get(hass).async_get(other.entity_id) is not None
+
+
+def test_removes_legacy_duplicate_circulation_pump_switches(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A duplicate left on either historical unique-id scheme is removed."""
+    mock_config_entry.add_to_hass(hass)
+    current = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(mock_config_entry, CIRCULATION_PUMP),
+        "circulation_pump",
+        domain="switch",
+    )
+    legacy = _register(
+        hass,
+        mock_config_entry,
+        f"{DOMAIN}_Stiebel Eltron_{CIRCULATION_PUMP}",
+        "legacy_circulation_pump",
+        domain="switch",
+    )
+
+    migration.async_remove_legacy_circulation_pump_switch(hass, mock_config_entry)
+
+    registry = er.async_get(hass)
+    assert registry.async_get(current.entity_id) is None
+    assert registry.async_get(legacy.entity_id) is None
 
 
 async def test_migrates_entities_of_the_configured_name_scheme(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,12 +1,16 @@
 """Tests for the sensor platform."""
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfEnergy, UnitOfFrequency, UnitOfPower
+from pystiebeleltron import ControllerModel
 import pytest
 
+from custom_components.stiebel_eltron_isg import sensor as sensor_module
 from custom_components.stiebel_eltron_isg.const import (
+    ACTIVE_ERROR,
     COMPRESSOR_HEATING,
     COMPRESSOR_HEATING_WATER,
     COMPRESSOR_SPEED,
@@ -34,6 +38,9 @@ from custom_components.stiebel_eltron_isg.sensor import (
     WPM_3I_SENSOR_TYPES,
     WPM_INVERTER_POWER_SENSOR_TYPES,
     WPM_SENSOR_TYPES,
+    StiebelEltronISGEnergySensor,
+    StiebelEltronISGSensor,
+    StiebelEltronSensorEntityDescription,
 )
 
 
@@ -47,6 +54,103 @@ def _wpm_3i(key: str):
 
 def _lwz(key: str):
     return next(d for d in LWZ_SENSOR_TYPES if d.key == key)
+
+
+def test_sensor_description_rejects_non_callable_register() -> None:
+    """Register references must use the API accessor contract."""
+    with pytest.raises(TypeError, match="must be a lambda expression"):
+        StiebelEltronSensorEntityDescription(
+            key="invalid",
+            modbus_register="legacy register token",
+        )
+
+
+async def test_setup_uses_wpm_3i_sensor_lists() -> None:
+    """WPM 3i receives both its regular and daily energy sensors."""
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(model=ControllerModel.WPM_3i),
+    )
+    add_entities = MagicMock()
+
+    with (
+        patch.object(
+            sensor_module,
+            "StiebelEltronISGSensor",
+            side_effect=lambda coordinator, config_entry, description: (
+                "sensor",
+                description.key,
+            ),
+        ),
+        patch.object(
+            sensor_module,
+            "StiebelEltronISGEnergySensor",
+            side_effect=lambda coordinator, config_entry, description: (
+                "energy",
+                description.key,
+            ),
+        ),
+    ):
+        await sensor_module.async_setup_entry(None, entry, add_entities)
+
+    entities = add_entities.call_args.args[0]
+    assert entities == [
+        *[("sensor", description.key) for description in WPM_3I_SENSOR_TYPES],
+        *[
+            ("energy", description.key)
+            for description in sensor_module.ENERGY_DAILY_SENSOR_TYPES
+        ],
+    ]
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "expected"),
+    [
+        (ACTIVE_ERROR, None, None),
+        (ACTIVE_ERROR, 0, "no error"),
+        (ACTIVE_ERROR, 32768, "no error"),
+        (ACTIVE_ERROR, 42, "error 42"),
+        ("ordinary", 21.5, 21.5),
+    ],
+)
+def test_sensor_native_value_formats_active_errors(key: str, value, expected) -> None:
+    """The active-error register gets labels while ordinary values pass through."""
+    entity = StiebelEltronISGSensor.__new__(StiebelEltronISGSensor)
+    entity.entity_description = SimpleNamespace(key=key)
+    entity.modbus_register = lambda api: None
+    entity.coordinator = SimpleNamespace(get_value=lambda accessor: value)
+
+    assert entity.native_value == expected
+
+
+@pytest.mark.parametrize(
+    ("has_value", "value", "expected_reset"),
+    [
+        (False, None, False),
+        (True, 1, False),
+        (True, 0, True),
+    ],
+)
+def test_energy_sensor_reset_time(
+    has_value: bool,
+    value,
+    expected_reset: bool,
+) -> None:
+    """Only an available counter that reads zero reports a reset."""
+    entity = StiebelEltronISGEnergySensor.__new__(StiebelEltronISGEnergySensor)
+    entity.modbus_register = lambda api: None
+    entity.coordinator = SimpleNamespace(
+        has_value=lambda accessor: has_value,
+        get_value=lambda accessor: value,
+    )
+    reset_time = object()
+
+    with patch.object(sensor_module.dt_util, "utcnow", return_value=reset_time):
+        result = entity.last_reset
+
+    if expected_reset:
+        assert result is reset_time
+    else:
+        assert result is None
 
 
 def test_wpm_exposes_compressor_runtime_hours() -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 
-from custom_components.stiebel_eltron_isg.const import CIRCULATION_PUMP
+from custom_components.stiebel_eltron_isg.const import SG_READY_INPUT_1
 from custom_components.stiebel_eltron_isg.switch import StiebelEltronISGSwitch
 
 
@@ -13,15 +13,15 @@ def _make_switch(key: str, last_update_success: bool) -> StiebelEltronISGSwitch:
     return entity
 
 
-def test_circulation_pump_switch_unavailable_when_last_update_failed() -> None:
-    """The always-on switches must still go unavailable on a failed update."""
-    entity = _make_switch(CIRCULATION_PUMP, last_update_success=False)
+def test_write_only_switch_unavailable_when_last_update_failed() -> None:
+    """A write-only switch must still go unavailable on a failed update."""
+    entity = _make_switch(SG_READY_INPUT_1, last_update_success=False)
 
     assert entity.available is False
 
 
-def test_circulation_pump_switch_available_when_update_succeeded() -> None:
-    """With a successful update the switch stays available."""
-    entity = _make_switch(CIRCULATION_PUMP, last_update_success=True)
+def test_write_only_switch_available_when_update_succeeded() -> None:
+    """With a successful update a write-only switch stays available."""
+    entity = _make_switch(SG_READY_INPUT_1, last_update_success=True)
 
     assert entity.available is True


### PR DESCRIPTION
Depends on the circulation pump fix and is based on that branch, because the
binary-sensor tests cover the entity that PR introduces. Please merge the
circulation pump PR first.

## Changes

Tests only, no production code touched.

## Tests

`tests/test_sensor.py`

- Model gates: WPM 3i uses its own sensor lists.
- The active-error sensor formats its raw value, including the no-error and the
  unknown-code case.
- Energy sensors expose the expected reset time, which is what the Energy
  Dashboard consumes.
- A description with a non-callable register is rejected.

`tests/test_binary_sensor.py`

- A binary sensor reads exactly its configured bit, so a wrong accessor cannot
  pass unnoticed.

`tests/test_coordinator.py`

- The WPM 3i coordinator initializes its model-specific API.

No dependency changes.
Part of #629.

## Summary by Sourcery

Expose the domestic hot water circulation pump as a read-only binary sensor and clean up legacy switch entities, while tightening behavior and model-gating for WPM 3i sensors and coordinators.

New Features:
- Add a dedicated circulation pump binary sensor for supported WPM and LWZ controllers, reflecting the read-only operating status.
- Ensure WPM 3i setups use their model-specific sensor lists and coordinator implementation.

Bug Fixes:
- Remove obsolete and legacy circulation pump switch entities that represented a non-writable status register, preventing invalid switch actions.

Enhancements:
- Clarify and enforce that sensor entity descriptions use callable Modbus register accessors.
- Refine active-error sensor value formatting, including no-error and unknown-code cases, and expose correct reset semantics for energy sensors.
- Restrict circulation pump exposure to controller models that actually provide the underlying status register and ensure binary sensors read the configured bit correctly.

Documentation:
- Document that the circulation pump is now exposed as a binary sensor instead of a switch on WPMsystem and LWZ R290, and that existing automations must be updated accordingly.

Tests:
- Add tests for WPM 3i sensor setup, active-error formatting, and energy sensor reset behavior.
- Add tests covering circulation pump binary sensor description, model gating, and read-back behavior, along with generic binary sensor bit-handling.
- Add migration tests verifying removal of obsolete and legacy circulation pump switch entities and tests for WPM 3i coordinator initialization.
- Adjust switch availability tests to focus on write-only switches rather than the removed circulation pump switch.