### PR TITLE
Cover setup and coordinator behavior

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,13 +1,14 @@
 """Tests for coordinator write actions."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from modbus_connection import ModbusError
-from pystiebeleltron import StiebelEltronModbusError
+from pystiebeleltron import ControllerModel, StiebelEltronModbusError
 import pytest
 
+from custom_components.stiebel_eltron_isg import coordinator as coordinator_module
 from custom_components.stiebel_eltron_isg.const import DOMAIN
 from custom_components.stiebel_eltron_isg.coordinator import (
     StiebelEltronDataCoordinator,
@@ -22,6 +23,117 @@ def _coordinator(api) -> StiebelEltronDataCoordinator:
     coordinator = StiebelEltronDataCoordinator.__new__(StiebelEltronDataCoordinator)
     coordinator._api = api
     return coordinator
+
+
+def test_for_unit_uses_the_active_connection() -> None:
+    """Unit access must be delegated to the shared connection."""
+    coordinator = _coordinator(SimpleNamespace())
+    connection = MagicMock()
+    coordinator._connection = connection
+
+    assert coordinator._for_unit(1) is connection.for_unit.return_value
+    connection.for_unit.assert_called_once_with(1)
+
+
+def test_for_unit_rejects_a_missing_connection() -> None:
+    """Access without a connection must fail explicitly."""
+    coordinator = _coordinator(SimpleNamespace())
+    coordinator._connection = None
+
+    with pytest.raises(RuntimeError, match="Connection not established"):
+        coordinator._for_unit(1)
+
+
+@pytest.mark.parametrize(
+    ("connection", "expected"),
+    [
+        (None, False),
+        (SimpleNamespace(connected=False), False),
+        (SimpleNamespace(connected=True), True),
+    ],
+)
+def test_is_connected_reflects_the_connection(connection, expected: bool) -> None:
+    """Connection state must include the not-yet-connected case."""
+    coordinator = _coordinator(SimpleNamespace())
+    coordinator._connection = connection
+
+    assert coordinator.is_connected is expected
+
+
+def test_host_returns_the_configured_address() -> None:
+    """The coordinator exposes the address used for its device."""
+    coordinator = _coordinator(SimpleNamespace())
+    coordinator._host = "isg.local"
+
+    assert coordinator.host == "isg.local"
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        (ControllerModel.LWZ, "LWA/LWZ"),
+        (ControllerModel.LWZ_x04_SOL, "LWZ"),
+        (ControllerModel.WPM_3, "WPM 3"),
+        (ControllerModel.WPM_3i, "WPM 3i"),
+        (ControllerModel.WPMsystem, "WPMsystem"),
+        (ControllerModel.LWZ_R290, "LWZ R290"),
+        (SimpleNamespace(name="FUTURE"), "other model (FUTURE)"),
+    ],
+)
+def test_model_name_is_readable(model, expected: str) -> None:
+    """Every known model and the forward-compatible fallback have a name."""
+    coordinator = _coordinator(SimpleNamespace())
+    coordinator._model = model
+
+    assert coordinator.model_name == expected
+
+
+def test_get_raw_data_combines_all_api_components() -> None:
+    """Diagnostics receive the rows of every API component."""
+    first = object()
+    second = object()
+    coordinator = _coordinator(SimpleNamespace(first=first, second=second))
+
+    with patch.object(
+        coordinator_module,
+        "field_rows",
+        side_effect=(
+            [("first", 1), ("shared", 1)],
+            [("second", 2), ("shared", 2)],
+        ),
+    ) as rows:
+        assert coordinator.get_raw_data() == {
+            "first": 1,
+            "second": 2,
+            "shared": 2,
+        }
+
+    assert rows.call_args_list[0].args == (first,)
+    assert rows.call_args_list[1].args == (second,)
+
+
+def test_get_value_returns_none_for_library_read_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A register read error makes one entity unavailable without crashing."""
+    coordinator = _coordinator(SimpleNamespace())
+
+    def failed_accessor(api):
+        raise StiebelEltronModbusError
+
+    assert coordinator.get_value(failed_accessor) is None
+    assert "Failed to get value from accessor" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(1, 1), (1.5, 1.5), (True, True), ("not numeric", None), (None, None)],
+)
+def test_get_value_only_accepts_numeric_states(value, expected) -> None:
+    """Entity state accessors may only return numeric Modbus values."""
+    coordinator = _coordinator(SimpleNamespace(value=value))
+
+    assert coordinator.get_value(lambda api: api.value) == expected
 
 
 async def test_write_component_value_writes_supported_field() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -19,6 +19,9 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.stiebel_eltron_isg.const import CURRENT_POWER_CONSUMPTION, DOMAIN
 from custom_components.stiebel_eltron_isg.entity import build_unique_id
 from custom_components.stiebel_eltron_isg.sensor import WPM_SENSOR_TYPES
+from custom_components.stiebel_eltron_isg.wpm3i_coordinator import (
+    StiebelEltronModbusWPM3iDataCoordinator,
+)
 
 
 async def test_async_setup_entry_success(
@@ -31,6 +34,23 @@ async def test_async_setup_entry_success(
 
     assert result is True
     assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_async_setup_entry_selects_wpm_3i_coordinator(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_get_controller_model: MagicMock,
+) -> None:
+    """WPM 3i controllers must use their model-specific API coordinator."""
+    mock_get_controller_model.return_value = ControllerModel.WPM_3i
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert isinstance(
+        mock_config_entry.runtime_data,
+        StiebelEltronModbusWPM3iDataCoordinator,
+    )
 
 
 async def test_setup_registers_every_wpm_sensor(
@@ -186,6 +206,22 @@ async def test_async_setup_entry_unknown_model(
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
+async def test_async_setup_entry_rejects_unhandled_model(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_get_controller_model: MagicMock,
+) -> None:
+    """A detected model without a coordinator must fail without retries."""
+    mock_get_controller_model.return_value = MagicMock(name="future_model")
+    mock_get_controller_model.return_value.name = "FUTURE"
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert result is False
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
 async def test_async_setup_entry_coordinator_update_fails(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -239,7 +275,6 @@ async def test_unload_entry_closes_connection(
     assert mock_modbus_connection.connected is False
 
 
-@pytest.mark.skip(reason="lingering timer issue")
 async def test_unload_entry_does_not_close_connection_if_platform_unload_fails(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -259,3 +294,9 @@ async def test_unload_entry_does_not_close_connection_if_platform_unload_fails(
 
     assert result is False
     assert mock_modbus_connection.connected is True
+
+    # Home Assistant puts the entry into FAILED_UNLOAD, which cannot be
+    # unloaded a second time. Stop the coordinator and connection explicitly
+    # so the deliberately failed unload does not leak resources from the test.
+    await mock_config_entry.runtime_data.async_shutdown()
+    await mock_modbus_connection.close()


### PR DESCRIPTION
The coordinator and the entry setup are the two modules everything else depends
on, and they were the least covered. The tests below are behavior oriented: they
assert what the coordinator reports to entities, not how it is implemented.

## Changes

Tests only, no production code touched.

## Tests

`tests/test_coordinator.py`

- `for_unit` uses the active connection and rejects a missing one.
- `is_connected` follows the connection state.
- `host` returns the configured address; the model name is readable for each
  controller model.
- `get_raw_data` combines all API components, which is what diagnostics rely on.
- `get_value` returns `None` when the library read fails, and accepts only
  numeric states, so a non-numeric library value cannot reach an entity.

`tests/test_init.py`

- WPM 3i selects its own coordinator.
- An unhandled controller model aborts setup instead of loading a wrong register
  map.

No dependency changes.
Part of #629.

## Summary by Sourcery

Expand test coverage for the coordinator and setup entry to validate connection handling, model naming, diagnostics data aggregation, and model-specific coordinator selection and setup failure behavior.

Tests:
- Add coordinator behavior tests for connection usage, connection state reporting, host and model name exposure, diagnostics raw data aggregation, and value handling for library errors and non-numeric states.
- Add setup entry tests ensuring WPM 3i uses its dedicated coordinator and that unknown or unhandled controller models cause setup to fail without retries.
- Adjust unload entry test to verify connection remains open on platform unload failure and explicitly shut down coordinator and connection to avoid leaking resources during tests.