### PR TITLE
Expose the DHW circulation pump as status instead of a switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ To change the IP address or port of the ISG, use **Reconfigure** in the three-do
 menu of the integration entry. It leaves the entities untouched, so nothing has to be
 matched up afterwards.
 
+The domestic hot water circulation pump is a read-only operating status on
+WPMsystem and LWZ R290. It is therefore exposed as
+`binary_sensor.<device>_circulation_pump`, not as a switch. Existing
+automations and dashboards that reference the former switch entity need to use
+the binary sensor instead; switch actions must be removed because the register
+was never writable.
+
 For contributors, the transition the earlier migration notes described is complete.
 The compatibility shims are gone, along with `probe.py` and `client_bridge.py`:
 

--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -21,7 +21,11 @@ from pystiebeleltron import (
 from .const import DEFAULT_PORT, UNIT_ID
 from .coordinator import StiebelEltronConfigEntry
 from .lwz_coordinator import StiebelEltronModbusLWZDataCoordinator
-from .migration import async_migrate_device_identifier, async_migrate_unique_ids
+from .migration import (
+    async_migrate_device_identifier,
+    async_migrate_unique_ids,
+    async_remove_legacy_circulation_pump_switch,
+)
 from .wpm3i_coordinator import StiebelEltronModbusWPM3iDataCoordinator
 from .wpm_coordinator import StiebelEltronModbusWPMDataCoordinator
 
@@ -75,6 +79,7 @@ async def async_setup_entry(
     # identifiers.
     async_migrate_device_identifier(hass, entry)
     await async_migrate_unique_ids(hass, entry, model)
+    async_remove_legacy_circulation_pump_switch(hass, entry)
 
     coordinator = None
 

--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -79,7 +79,7 @@ async def async_setup_entry(
     # identifiers.
     async_migrate_device_identifier(hass, entry)
     await async_migrate_unique_ids(hass, entry, model)
-    async_remove_legacy_circulation_pump_switch(hass, entry)
+    async_remove_legacy_circulation_pump_switch(hass, entry, model)
 
     coordinator = None
 

--- a/custom_components/stiebel_eltron_isg/binary_sensor.py
+++ b/custom_components/stiebel_eltron_isg/binary_sensor.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
@@ -19,6 +20,7 @@ from .const import (
     BUFFER_4_CHARGING_PUMP,
     BUFFER_5_CHARGING_PUMP,
     BUFFER_6_CHARGING_PUMP,
+    CIRCULATION_PUMP,
     COMPRESSOR_ON,
     COOLING_MODE,
     DHW_CHARGING_PUMP,
@@ -405,6 +407,18 @@ WPM_BINARY_SENSOR_TYPES = [
     ),
 ]
 
+# Only WPMsystem and LWZ_R290 are confirmed to expose this system-state field,
+# see #607. Do not widen the model gate without controller-specific evidence.
+# pystiebeleltron exposes no matching writable WPM/LWZ parameter.
+CIRCULATION_PUMP_BINARY_SENSOR_TYPES = [
+    StiebelEltronBinarySensorEntityDescription(
+        key=CIRCULATION_PUMP,
+        translation_key=CIRCULATION_PUMP,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        modbus_register=lambda api: api.system_state.dhw_circulation_pump,
+    ),
+]
+
 
 LWZ_BINARY_SENSOR_TYPES = [
     StiebelEltronBinarySensorEntityDescription(
@@ -567,6 +581,17 @@ async def async_setup_entry(
             )
             for description in LWZ_BINARY_SENSOR_TYPES
         ]
+
+    if coordinator.model in (ControllerModel.LWZ_R290, ControllerModel.WPMsystem):
+        entities.extend(
+            StiebelEltronISGBinarySensor(
+                coordinator,
+                entry,
+                description,
+            )
+            for description in CIRCULATION_PUMP_BINARY_SENSOR_TYPES
+        )
+
     async_add_devices(entities)
 
 

--- a/custom_components/stiebel_eltron_isg/migration.py
+++ b/custom_components/stiebel_eltron_isg/migration.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from pystiebeleltron import ControllerModel
 
-from .const import DOMAIN, HEATER_PRESSURE
+from .const import CIRCULATION_PUMP, DOMAIN, HEATER_PRESSURE
 from .coordinator import StiebelEltronConfigEntry, coordinator_display_name
 from .entity import build_unique_id
 
@@ -31,6 +31,35 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 # entity would be migrated to an id that no entity description produces and stay
 # orphaned for the second time.
 _RENAMED_KEYS = {"heating_pressure": HEATER_PRESSURE}
+
+
+@callback
+def async_remove_legacy_circulation_pump_switch(
+    hass: HomeAssistant,
+    entry: StiebelEltronConfigEntry,
+) -> None:
+    """Remove the switch that represented a read-only status register."""
+    registry = er.async_get(hass)
+    obsolete = [
+        registry_entry
+        for registry_entry in er.async_entries_for_config_entry(
+            registry,
+            entry.entry_id,
+        )
+        if registry_entry.domain == "switch"
+        and (
+            registry_entry.unique_id == build_unique_id(entry, CIRCULATION_PUMP)
+            or registry_entry.unique_id.endswith(f"_{CIRCULATION_PUMP}")
+        )
+    ]
+    for registry_entry in obsolete:
+        registry.async_remove(registry_entry.entity_id)
+
+    if obsolete:
+        _LOGGER.info(
+            "Removed %s obsolete circulation pump switch entities",
+            len(obsolete),
+        )
 
 
 def _legacy_name(entry: StiebelEltronConfigEntry) -> str:

--- a/custom_components/stiebel_eltron_isg/migration.py
+++ b/custom_components/stiebel_eltron_isg/migration.py
@@ -37,9 +37,14 @@ _RENAMED_KEYS = {"heating_pressure": HEATER_PRESSURE}
 def async_remove_legacy_circulation_pump_switch(
     hass: HomeAssistant,
     entry: StiebelEltronConfigEntry,
+    model: ControllerModel,
 ) -> None:
     """Remove the switch that represented a read-only status register."""
     registry = er.async_get(hass)
+    obsolete_unique_ids = {
+        build_unique_id(entry, CIRCULATION_PUMP),
+        *(f"{prefix}{CIRCULATION_PUMP}" for prefix in _legacy_prefixes(entry, model)),
+    }
     obsolete = [
         registry_entry
         for registry_entry in er.async_entries_for_config_entry(
@@ -47,10 +52,7 @@ def async_remove_legacy_circulation_pump_switch(
             entry.entry_id,
         )
         if registry_entry.domain == "switch"
-        and (
-            registry_entry.unique_id == build_unique_id(entry, CIRCULATION_PUMP)
-            or registry_entry.unique_id.endswith(f"_{CIRCULATION_PUMP}")
-        )
+        and registry_entry.unique_id in obsolete_unique_ids
     ]
     for registry_entry in obsolete:
         registry.async_remove(registry_entry.entity_id)

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -390,6 +390,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Circulation Pump"
+            },
             "pump_on_hk1": {
                 "name": "Pump HK1"
             },
@@ -657,9 +660,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready Input 2"
-            },
-            "circulation_pump": {
-                "name": "Circulation Pump"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/switch.py
+++ b/custom_components/stiebel_eltron_isg/switch.py
@@ -11,9 +11,8 @@ from homeassistant.components.switch import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pystiebeleltron import ControllerModel
 
-from .const import CIRCULATION_PUMP, SG_READY_ACTIVE, SG_READY_INPUT_1, SG_READY_INPUT_2
+from .const import SG_READY_ACTIVE, SG_READY_INPUT_1, SG_READY_INPUT_2
 from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
 from .entity import StiebelEltronISGEntity
 
@@ -67,18 +66,6 @@ SWITCH_TYPES = [
     ),
 ]
 
-# Only for controllers that expose a domestic hot water circulation pump.
-CIRCULATION_PUMP_SWITCH_TYPES = [
-    StiebelEltronSwitchEntityDescription(
-        key=CIRCULATION_PUMP,
-        translation_key=CIRCULATION_PUMP,
-        device_class=SwitchDeviceClass.SWITCH,
-        modbus_register=lambda api: api.system_state.dhw_circulation_pump,
-        write_component="system_state",
-        write_field="dhw_circulation_pump",
-    ),
-]
-
 
 async def async_setup_entry(
     _hass: HomeAssistant,
@@ -96,17 +83,6 @@ async def async_setup_entry(
         )
         for description in SWITCH_TYPES
     ]
-
-    if coordinator.model in (ControllerModel.LWZ_R290, ControllerModel.WPMsystem):
-        # Add the circulation pump switch for WPM systems
-        entities.extend(
-            StiebelEltronISGSwitch(
-                coordinator,
-                entry,
-                description,
-            )
-            for description in CIRCULATION_PUMP_SWITCH_TYPES
-        )
 
     async_add_devices(entities)
 
@@ -162,11 +138,7 @@ class StiebelEltronISGSwitch(StiebelEltronISGEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        if self.entity_description.key in (
-            CIRCULATION_PUMP,
-            SG_READY_INPUT_1,
-            SG_READY_INPUT_2,
-        ):
+        if self.entity_description.key in (SG_READY_INPUT_1, SG_READY_INPUT_2):
             # These writable switches stay operable even when the device does
             # not report a read-back value, but must still go unavailable when
             # the coordinator can no longer reach the device.

--- a/custom_components/stiebel_eltron_isg/translations/cz.json
+++ b/custom_components/stiebel_eltron_isg/translations/cz.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Cirkulační čerpadlo"
+            },
             "pump_on_hk1": {
                 "name": "Čerpadlo TO 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready vstup 2"
-            },
-            "circulation_pump": {
-                "name": "Cirkulační čerpadlo"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -390,6 +390,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Zirkulationspumpe"
+            },
             "pump_on_hk1": {
                 "name": "Pumpe HK 1"
             },
@@ -657,9 +660,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready Eingang 2"
-            },
-            "circulation_pump": {
-                "name": "Zirkulationspumpe"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -379,6 +379,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Circulation Pump"
+            },
             "pump_on_hk1": {
                 "name": "Pump HK1"
             },
@@ -646,9 +649,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready Input 2"
-            },
-            "circulation_pump": {
-                "name": "Circulation Pump"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/fr.json
+++ b/custom_components/stiebel_eltron_isg/translations/fr.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Pompe de circulation"
+            },
             "pump_on_hk1": {
                 "name": "Pompe CC 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready entrée 2"
-            },
-            "circulation_pump": {
-                "name": "Pompe de circulation"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/it.json
+++ b/custom_components/stiebel_eltron_isg/translations/it.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Pompa di circolazione"
+            },
             "pump_on_hk1": {
                 "name": "Pompa CC 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready ingresso 2"
-            },
-            "circulation_pump": {
-                "name": "Pompa di circolazione"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/pt.json
+++ b/custom_components/stiebel_eltron_isg/translations/pt.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Bomba de circulação"
+            },
             "pump_on_hk1": {
                 "name": "Bomba CC 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready entrada 2"
-            },
-            "circulation_pump": {
-                "name": "Bomba de circulação"
             }
         },
         "button": {

--- a/custom_components/stiebel_eltron_isg/translations/sk.json
+++ b/custom_components/stiebel_eltron_isg/translations/sk.json
@@ -346,6 +346,9 @@
             }
         },
         "binary_sensor": {
+            "circulation_pump": {
+                "name": "Cirkulačné čerpadlo"
+            },
             "pump_on_hk1": {
                 "name": "Čerpadlo TO 1"
             },
@@ -601,9 +604,6 @@
             },
             "sg_ready_input_2": {
                 "name": "SG Ready vstup 2"
-            },
-            "circulation_pump": {
-                "name": "Cirkulačné čerpadlo"
             }
         },
         "button": {

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,73 @@
+"""Tests for the binary sensor platform."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from pystiebeleltron import ControllerModel
+import pytest
+
+from custom_components.stiebel_eltron_isg import binary_sensor
+from custom_components.stiebel_eltron_isg.const import CIRCULATION_PUMP
+from custom_components.stiebel_eltron_isg.switch import SWITCH_TYPES
+
+
+def test_circulation_pump_is_a_running_status() -> None:
+    """The read-only system-state register must be represented as a status."""
+    (description,) = binary_sensor.CIRCULATION_PUMP_BINARY_SENSOR_TYPES
+    api = SimpleNamespace(
+        system_state=SimpleNamespace(dhw_circulation_pump=1),
+    )
+
+    assert description.key == CIRCULATION_PUMP
+    assert description.device_class is BinarySensorDeviceClass.RUNNING
+    assert description.modbus_register(api) == 1
+    assert CIRCULATION_PUMP not in {description.key for description in SWITCH_TYPES}
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        (ControllerModel.WPMsystem, True),
+        (ControllerModel.LWZ_R290, True),
+        (ControllerModel.WPM_3, False),
+        (ControllerModel.LWZ, False),
+    ],
+)
+async def test_circulation_pump_is_only_added_for_supported_models(
+    model: ControllerModel,
+    expected: bool,
+) -> None:
+    """Only controllers exposing the register get the status entity."""
+    entry = SimpleNamespace(runtime_data=SimpleNamespace(model=model))
+    async_add_entities = MagicMock()
+
+    with patch.object(
+        binary_sensor,
+        "StiebelEltronISGBinarySensor",
+        side_effect=lambda _coordinator, _entry, description: description.key,
+    ):
+        await binary_sensor.async_setup_entry(None, entry, async_add_entities)
+
+    entities = async_add_entities.call_args.args[0]
+    assert (CIRCULATION_PUMP in entities) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, False), (0, False), (1, True)],
+)
+def test_circulation_pump_reports_the_read_back_state(value, expected: bool) -> None:
+    """The real entity maps the status register to an on/off state."""
+    (description,) = binary_sensor.CIRCULATION_PUMP_BINARY_SENSOR_TYPES
+    api = SimpleNamespace(
+        system_state=SimpleNamespace(dhw_circulation_pump=value),
+    )
+    entity = binary_sensor.StiebelEltronISGBinarySensor.__new__(
+        binary_sensor.StiebelEltronISGBinarySensor
+    )
+    entity.modbus_register = description.modbus_register
+    entity.bit_number = description.bit_number
+    entity.coordinator = SimpleNamespace(get_value=lambda accessor: accessor(api))
+
+    assert entity.is_on is expected

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -50,7 +50,7 @@ async def test_circulation_pump_is_only_added_for_supported_models(
         await binary_sensor.async_setup_entry(None, entry, async_add_entities)
 
     entities = async_add_entities.call_args.args[0]
-    assert (CIRCULATION_PUMP in entities) is expected
+    assert entities.count(CIRCULATION_PUMP) == int(expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -82,11 +82,15 @@ _DESCRIPTION_LISTS: list[tuple[str, str, list[Any]]] = [
     ("WPM_BINARY_SENSOR_TYPES", WPM, binary_sensor.WPM_BINARY_SENSOR_TYPES),
     ("WPM_3I_BINARY_SENSOR_TYPES", WPM_3I, binary_sensor.WPM_3I_BINARY_SENSOR_TYPES),
     ("LWZ_BINARY_SENSOR_TYPES", LWZ, binary_sensor.LWZ_BINARY_SENSOR_TYPES),
+    # WPMsystem and LWZ_R290, both of which are served by the WPM api.
+    (
+        "CIRCULATION_PUMP_BINARY_SENSOR_TYPES",
+        WPM,
+        binary_sensor.CIRCULATION_PUMP_BINARY_SENSOR_TYPES,
+    ),
     ("SWITCH_TYPES", WPM, switch.SWITCH_TYPES),
     ("SWITCH_TYPES", WPM_3I, switch.SWITCH_TYPES),
     ("SWITCH_TYPES", LWZ, switch.SWITCH_TYPES),
-    # WPMsystem and LWZ_R290, both of which are served by the WPM api.
-    ("CIRCULATION_PUMP_SWITCH_TYPES", WPM, switch.CIRCULATION_PUMP_SWITCH_TYPES),
     ("WPM_SELECT_TYPES", WPM, select.WPM_SELECT_TYPES),
     ("WPM_SELECT_TYPES", WPM_3I, select.WPM_SELECT_TYPES),
     ("LWZ_SELECT_TYPES", LWZ, select.LWZ_SELECT_TYPES),

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -4,6 +4,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from pystiebeleltron import ControllerModel
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -62,7 +63,11 @@ def test_removes_obsolete_circulation_pump_switch(
         domain="switch",
     )
 
-    migration.async_remove_legacy_circulation_pump_switch(hass, mock_config_entry)
+    migration.async_remove_legacy_circulation_pump_switch(
+        hass,
+        mock_config_entry,
+        ControllerModel.WPM_3,
+    )
 
     assert er.async_get(hass).async_get(obsolete.entity_id) is None
 
@@ -81,9 +86,39 @@ def test_circulation_pump_cleanup_leaves_other_switches_untouched(
         domain="switch",
     )
 
-    migration.async_remove_legacy_circulation_pump_switch(hass, mock_config_entry)
+    migration.async_remove_legacy_circulation_pump_switch(
+        hass,
+        mock_config_entry,
+        ControllerModel.WPM_3,
+    )
 
     assert er.async_get(hass).async_get(other.entity_id) is not None
+
+
+def test_circulation_pump_cleanup_requires_an_exact_legacy_id(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A coincidental key suffix must not make an unrelated switch removable."""
+    mock_config_entry.add_to_hass(hass)
+    unrelated = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(
+            mock_config_entry,
+            f"unrelated_{CIRCULATION_PUMP}",
+        ),
+        "unrelated_circulation_pump",
+        domain="switch",
+    )
+
+    migration.async_remove_legacy_circulation_pump_switch(
+        hass,
+        mock_config_entry,
+        ControllerModel.WPM_3,
+    )
+
+    assert er.async_get(hass).async_get(unrelated.entity_id) is not None
 
 
 def test_removes_legacy_duplicate_circulation_pump_switches(
@@ -106,12 +141,24 @@ def test_removes_legacy_duplicate_circulation_pump_switches(
         "legacy_circulation_pump",
         domain="switch",
     )
+    model_legacy = _register(
+        hass,
+        mock_config_entry,
+        f"{DOMAIN}_{MODEL_NAME}_{CIRCULATION_PUMP}",
+        "model_legacy_circulation_pump",
+        domain="switch",
+    )
 
-    migration.async_remove_legacy_circulation_pump_switch(hass, mock_config_entry)
+    migration.async_remove_legacy_circulation_pump_switch(
+        hass,
+        mock_config_entry,
+        ControllerModel.WPM_3,
+    )
 
     registry = er.async_get(hass)
     assert registry.async_get(current.entity_id) is None
     assert registry.async_get(legacy.entity_id) is None
+    assert registry.async_get(model_legacy.entity_id) is None
 
 
 async def test_migrates_entities_of_the_configured_name_scheme(

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -8,7 +8,8 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.stiebel_eltron_isg import migration
-from custom_components.stiebel_eltron_isg.const import DOMAIN
+from custom_components.stiebel_eltron_isg.const import CIRCULATION_PUMP, DOMAIN
+from custom_components.stiebel_eltron_isg.entity import build_unique_id
 
 # The model the mock_get_controller_model fixture reports, and the display name
 # the coordinator derives from it.
@@ -45,6 +46,72 @@ def _register(
         config_entry=entry,
         suggested_object_id=object_id,
     )
+
+
+def test_removes_obsolete_circulation_pump_switch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """The domain change must not leave the old switch in the registry."""
+    mock_config_entry.add_to_hass(hass)
+    obsolete = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(mock_config_entry, CIRCULATION_PUMP),
+        "circulation_pump",
+        domain="switch",
+    )
+
+    migration.async_remove_legacy_circulation_pump_switch(hass, mock_config_entry)
+
+    assert er.async_get(hass).async_get(obsolete.entity_id) is None
+
+
+def test_circulation_pump_cleanup_leaves_other_switches_untouched(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Only the obsolete entity with the exact unique id is removed."""
+    mock_config_entry.add_to_hass(hass)
+    other = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(mock_config_entry, "sg_ready_active"),
+        "sg_ready_active",
+        domain="switch",
+    )
+
+    migration.async_remove_legacy_circulation_pump_switch(hass, mock_config_entry)
+
+    assert er.async_get(hass).async_get(other.entity_id) is not None
+
+
+def test_removes_legacy_duplicate_circulation_pump_switches(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A duplicate left on either historical unique-id scheme is removed."""
+    mock_config_entry.add_to_hass(hass)
+    current = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(mock_config_entry, CIRCULATION_PUMP),
+        "circulation_pump",
+        domain="switch",
+    )
+    legacy = _register(
+        hass,
+        mock_config_entry,
+        f"{DOMAIN}_Stiebel Eltron_{CIRCULATION_PUMP}",
+        "legacy_circulation_pump",
+        domain="switch",
+    )
+
+    migration.async_remove_legacy_circulation_pump_switch(hass, mock_config_entry)
+
+    registry = er.async_get(hass)
+    assert registry.async_get(current.entity_id) is None
+    assert registry.async_get(legacy.entity_id) is None
 
 
 async def test_migrates_entities_of_the_configured_name_scheme(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2,7 +2,12 @@
 
 from types import SimpleNamespace
 
-from custom_components.stiebel_eltron_isg.const import SG_READY_INPUT_1
+import pytest
+
+from custom_components.stiebel_eltron_isg.const import (
+    SG_READY_INPUT_1,
+    SG_READY_INPUT_2,
+)
 from custom_components.stiebel_eltron_isg.switch import StiebelEltronISGSwitch
 
 
@@ -13,15 +18,17 @@ def _make_switch(key: str, last_update_success: bool) -> StiebelEltronISGSwitch:
     return entity
 
 
-def test_write_only_switch_unavailable_when_last_update_failed() -> None:
+@pytest.mark.parametrize("key", [SG_READY_INPUT_1, SG_READY_INPUT_2])
+def test_write_only_switch_unavailable_when_last_update_failed(key: str) -> None:
     """A write-only switch must still go unavailable on a failed update."""
-    entity = _make_switch(SG_READY_INPUT_1, last_update_success=False)
+    entity = _make_switch(key, last_update_success=False)
 
     assert entity.available is False
 
 
-def test_write_only_switch_available_when_update_succeeded() -> None:
+@pytest.mark.parametrize("key", [SG_READY_INPUT_1, SG_READY_INPUT_2])
+def test_write_only_switch_available_when_update_succeeded(key: str) -> None:
     """With a successful update a write-only switch stays available."""
-    entity = _make_switch(SG_READY_INPUT_1, last_update_success=True)
+    entity = _make_switch(key, last_update_success=True)
 
     assert entity.available is True

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 
-from custom_components.stiebel_eltron_isg.const import CIRCULATION_PUMP
+from custom_components.stiebel_eltron_isg.const import SG_READY_INPUT_1
 from custom_components.stiebel_eltron_isg.switch import StiebelEltronISGSwitch
 
 
@@ -13,15 +13,15 @@ def _make_switch(key: str, last_update_success: bool) -> StiebelEltronISGSwitch:
     return entity
 
 
-def test_circulation_pump_switch_unavailable_when_last_update_failed() -> None:
-    """The always-on switches must still go unavailable on a failed update."""
-    entity = _make_switch(CIRCULATION_PUMP, last_update_success=False)
+def test_write_only_switch_unavailable_when_last_update_failed() -> None:
+    """A write-only switch must still go unavailable on a failed update."""
+    entity = _make_switch(SG_READY_INPUT_1, last_update_success=False)
 
     assert entity.available is False
 
 
-def test_circulation_pump_switch_available_when_update_succeeded() -> None:
-    """With a successful update the switch stays available."""
-    entity = _make_switch(CIRCULATION_PUMP, last_update_success=True)
+def test_write_only_switch_available_when_update_succeeded() -> None:
+    """With a successful update a write-only switch stays available."""
+    entity = _make_switch(SG_READY_INPUT_1, last_update_success=True)
 
     assert entity.available is True


### PR DESCRIPTION
Fixes #607. On WPMsystem and LWZ R290 the domestic hot water circulation pump is
read from the system-state block, which is an input register. The entity was
offered as a switch, so `switch.turn_on` and `switch.turn_off` looked available
but could never take effect. `pystiebeleltron` exposes no writable WPM or LWZ
parameter for this pump, so the fix is to stop claiming an action instead of
looking for a register to write.

## Changes

- `binary_sensor.py`: add the circulation pump as a `RUNNING` binary sensor,
  gated to `ControllerModel.LWZ_R290` and `ControllerModel.WPMsystem`, reading
  `api.system_state.dhw_circulation_pump`. The gate keeps the same two models
  that are confirmed to serve the field; widening it needs controller-specific
  evidence.
- `switch.py`: remove the circulation pump description and its model gate. The
  availability exception for entities without a read-back now applies only to the
  SG Ready inputs, where it is actually correct.
- `migration.py`: `async_remove_legacy_circulation_pump_switch` removes the
  obsolete switch registry entries during setup, so users do not keep a dead
  entity that would silently accept service calls.
- Move the `circulation_pump` name from the `switch` to the `binary_sensor`
  section in `strings.json` and all seven translations.
- README: document the change and what has to be adjusted.

## Tests

- Binary sensor: state from the register, and the model gate for both directions.
- Migration: the legacy switch is removed, matching entries of other domains and
  other config entries are left alone.
- Switch tests and the entity-description test updated to the reduced switch set.

## Breaking change

`switch.<device>_circulation_pump` disappears and is replaced by
`binary_sensor.<device>_circulation_pump`. Automations, scripts and dashboards
that read the switch state must reference the binary sensor; `switch.turn_on` and
`switch.turn_off` calls must be removed, because that register was never
writable. Long-term statistics are not affected, these are binary states.
Part of #629.

## Summary by Sourcery

Expose the domestic hot water circulation pump as a read-only status entity instead of a writable switch and clean up legacy switch entries.

New Features:
- Add a RUNNING binary sensor for the domestic hot water circulation pump on WPMsystem and LWZ R290 controllers, reading the system-state register.

Bug Fixes:
- Prevent users from calling ineffective switch actions on the domestic hot water circulation pump by no longer exposing it as a writable switch.

Enhancements:
- Gate the new circulation pump status entity to controller models that are confirmed to expose the relevant system-state field.
- Adjust switch availability handling so the special-case for entities without read-back applies only to SG Ready inputs.

Documentation:
- Update README to explain that the circulation pump is now exposed as a binary sensor, how existing automations and dashboards must be updated, and that switch actions are no longer supported.

Tests:
- Add binary sensor tests covering the circulation pump description, model gating, and state mapping from the system-state register.
- Add migration tests verifying removal of obsolete circulation pump switch entities while leaving other switches untouched.
- Update switch and entity-description tests to reflect the removal of the circulation pump switch.

Chores:
- Introduce a migration step that removes obsolete and legacy circulation pump switch entities during integration setup to avoid dead entities.