### PR TITLE
Use a concrete stub for the unsupported future model

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the STIEBEL ELTRON integration."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.config_entries import ConfigEntryState
@@ -212,8 +213,7 @@ async def test_async_setup_entry_rejects_unhandled_model(
     mock_get_controller_model: MagicMock,
 ) -> None:
     """A detected model without a coordinator must fail without retries."""
-    mock_get_controller_model.return_value = MagicMock(name="future_model")
-    mock_get_controller_model.return_value.name = "FUTURE"
+    mock_get_controller_model.return_value = SimpleNamespace(name="FUTURE")
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.async_setup(mock_config_entry.entry_id)


### PR DESCRIPTION
Follow-up to #626, which was merged before this small review remark could be
included. Test-only.

The unhandled-model test simulated a future controller model with a
`MagicMock`. That is a poor stand-in for two reasons:

- `MagicMock(name=...)` sets the mock's display name, not the `.name`
  attribute the production code reads, so the test needed a second line to
  patch `.name` back in — an easy trap to repeat.
- A `MagicMock` auto-creates every attribute that is asked for. If setup ever
  started reading something else off the model, the test would silently keep
  passing instead of failing.

`SimpleNamespace(name="FUTURE")` models the minimal contract the setup path
actually relies on and raises `AttributeError` on anything beyond it.

## Change

- `tests/test_init.py`: replace the two-line `MagicMock` stub in
  `test_async_setup_entry_rejects_unhandled_model` with
  `SimpleNamespace(name="FUTURE")`, plus the `types` import.

## Verification

- `pytest`: 600 passed, 3 skipped
- Ruff check and format: clean

No production code, behavior, or dependency changes.

## Summary by Sourcery

Tests:
- Update the unhandled-model test to use a SimpleNamespace-based stub instead of a MagicMock to make attribute usage more explicit and robust.