### PR TITLE
Raise a Repair for controllers the integration cannot serve

### DIFF
--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -42,10 +42,31 @@ _PLATFORMS: list[Platform] = [
     Platform.CLIMATE,
 ]
 
+_ISSUE_TRACKER = "https://github.com/pail23/stiebel_eltron_isg_component/issues"
+
 
 def _unsupported_controller_issue_id(entry: StiebelEltronConfigEntry) -> str:
     """Return the stable repair issue id for a config entry."""
     return f"unsupported_controller_{entry.entry_id}"
+
+
+def _create_unsupported_controller_issue(
+    hass: HomeAssistant,
+    entry: StiebelEltronConfigEntry,
+    model_id: object,
+) -> None:
+    """Tell the user how to handle a controller without integration support."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        _unsupported_controller_issue_id(entry),
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        learn_more_url=_ISSUE_TRACKER,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="unsupported_controller",
+        translation_placeholders={"model_id": str(model_id)},
+    )
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
@@ -76,30 +97,10 @@ async def async_setup_entry(
         # transient modbus glitch: fail cleanly instead of retrying forever.
         # Adding support requires a pystiebeleltron update, which reloads the
         # entry anyway.
-        ir.async_create_issue(
-            hass,
-            DOMAIN,
-            _unsupported_controller_issue_id(entry),
-            is_fixable=False,
-            issue_domain=DOMAIN,
-            severity=ir.IssueSeverity.ERROR,
-            translation_key="unsupported_controller",
-            translation_placeholders={"model_id": str(exception.model_id)},
-        )
+        _create_unsupported_controller_issue(hass, entry, exception.model_id)
         raise ConfigEntryError(
             f"Unsupported controller model: {exception}"
         ) from exception
-
-    # A library update can add the model while this repair still exists from an
-    # earlier setup attempt.
-    ir.async_delete_issue(hass, DOMAIN, _unsupported_controller_issue_id(entry))
-
-    # Both have to run before the platforms are set up, so that the entities are
-    # added to the registry entries and the device that already carry their new
-    # identifiers.
-    async_migrate_device_identifier(hass, entry)
-    await async_migrate_unique_ids(hass, entry, model)
-    async_remove_legacy_circulation_pump_switch(hass, entry, model)
 
     coordinator = None
 
@@ -127,7 +128,21 @@ async def async_setup_entry(
             host,
         )
     else:
+        _create_unsupported_controller_issue(
+            hass, entry, getattr(model, "value", model)
+        )
         raise ConfigEntryError(f"Unsupported controller model: {model}")
+
+    # A library and integration update can add the model while this repair still
+    # exists from an earlier setup attempt.
+    ir.async_delete_issue(hass, DOMAIN, _unsupported_controller_issue_id(entry))
+
+    # Both have to run before the platforms are set up, so that the entities are
+    # added to the registry entries and the device that already carry their new
+    # identifiers.
+    async_migrate_device_identifier(hass, entry)
+    await async_migrate_unique_ids(hass, entry, model)
+    async_remove_legacy_circulation_pump_switch(hass, entry, model)
 
     entry.runtime_data = coordinator
 
@@ -150,3 +165,11 @@ async def async_unload_entry(
 ) -> bool:
     """Handle removal of an entry."""
     return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
+
+
+async def async_remove_entry(
+    hass: HomeAssistant,
+    entry: StiebelEltronConfigEntry,
+) -> None:
+    """Remove repairs that belong to a deleted config entry."""
+    ir.async_delete_issue(hass, DOMAIN, _unsupported_controller_issue_id(entry))

--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -9,6 +9,7 @@ import logging
 from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
+from homeassistant.helpers import issue_registry as ir
 from modbus_connection import ModbusError
 from modbus_connection.pymodbus import connect_tcp
 from pystiebeleltron import (
@@ -18,7 +19,7 @@ from pystiebeleltron import (
     get_controller_model,
 )
 
-from .const import DEFAULT_PORT, UNIT_ID
+from .const import DEFAULT_PORT, DOMAIN, UNIT_ID
 from .coordinator import StiebelEltronConfigEntry
 from .lwz_coordinator import StiebelEltronModbusLWZDataCoordinator
 from .migration import (
@@ -40,6 +41,11 @@ _PLATFORMS: list[Platform] = [
     Platform.SELECT,
     Platform.CLIMATE,
 ]
+
+
+def _unsupported_controller_issue_id(entry: StiebelEltronConfigEntry) -> str:
+    """Return the stable repair issue id for a config entry."""
+    return f"unsupported_controller_{entry.entry_id}"
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
@@ -70,9 +76,23 @@ async def async_setup_entry(
         # transient modbus glitch: fail cleanly instead of retrying forever.
         # Adding support requires a pystiebeleltron update, which reloads the
         # entry anyway.
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            _unsupported_controller_issue_id(entry),
+            is_fixable=False,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="unsupported_controller",
+            translation_placeholders={"model_id": str(exception.model_id)},
+        )
         raise ConfigEntryError(
             f"Unsupported controller model: {exception}"
         ) from exception
+
+    # A library update can add the model while this repair still exists from an
+    # earlier setup attempt.
+    ir.async_delete_issue(hass, DOMAIN, _unsupported_controller_issue_id(entry))
 
     # Both have to run before the platforms are set up, so that the entities are
     # added to the registry entries and the device that already carry their new

--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -61,7 +61,6 @@ def _create_unsupported_controller_issue(
         DOMAIN,
         _unsupported_controller_issue_id(entry),
         is_fixable=False,
-        issue_domain=DOMAIN,
         learn_more_url=_ISSUE_TRACKER,
         severity=ir.IssueSeverity.ERROR,
         translation_key="unsupported_controller",

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -51,7 +51,7 @@
     "issues": {
         "unsupported_controller": {
             "title": "Unsupported controller model",
-            "description": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and try reloading the entry. If the issue remains, report this model ID in the project issue tracker."
+            "description": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. The entry remains unavailable until support is released in the device library and this integration. Update the integration and try reloading the entry. If the issue remains, report this model ID in the project issue tracker."
         }
     },
     "entity": {

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -48,6 +48,12 @@
             "message": "The setting {field} could not be written because communication with the heat pump failed."
         }
     },
+    "issues": {
+        "unsupported_controller": {
+            "title": "Unsupported controller model",
+            "description": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and try reloading the entry. If the issue remains, report this model ID in the project issue tracker."
+        }
+    },
     "entity": {
         "sensor": {
             "actual_temperature": {

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -51,7 +51,7 @@
     "issues": {
         "unsupported_controller": {
             "title": "Unsupported controller model",
-            "description": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. The entry remains unavailable until support is released in the device library and this integration. Update the integration and try reloading the entry. If the issue remains, report this model ID in the project issue tracker."
+            "description": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and reload the entry. If it remains unavailable, support has not yet been released in both the device library and this integration; report the model ID in the project issue tracker."
         }
     },
     "entity": {

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -48,7 +48,7 @@
     "issues": {
         "unsupported_controller": {
             "title": "Nicht unterstütztes Reglermodell",
-            "description": "Das ISG meldet die Reglermodell-ID {model_id}, die von dieser Version der Integration nicht unterstützt wird. Der Eintrag bleibt nicht verfügbar, bis die Gerätebibliothek und diese Integration das Modell unterstützen. Aktualisieren Sie die Integration und laden Sie den Eintrag erneut. Falls das Problem bestehen bleibt, melden Sie diese Modell-ID im Issue-Tracker des Projekts."
+            "description": "Das ISG meldet die Reglermodell-ID {model_id}, die von dieser Version der Integration nicht unterstützt wird. Aktualisieren Sie die Integration und laden Sie den Eintrag erneut. Falls er weiterhin nicht verfügbar ist, wurde die Unterstützung noch nicht in der Gerätebibliothek und dieser Integration veröffentlicht; melden Sie die Modell-ID im Issue-Tracker des Projekts."
         }
     },
     "entity": {

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -48,7 +48,7 @@
     "issues": {
         "unsupported_controller": {
             "title": "Nicht unterstütztes Reglermodell",
-            "description": "Das ISG meldet die Reglermodell-ID {model_id}, die von dieser Version der Integration nicht unterstützt wird. Aktualisieren Sie die Integration und laden Sie den Eintrag erneut. Falls das Problem bestehen bleibt, melden Sie diese Modell-ID im Issue-Tracker des Projekts."
+            "description": "Das ISG meldet die Reglermodell-ID {model_id}, die von dieser Version der Integration nicht unterstützt wird. Der Eintrag bleibt nicht verfügbar, bis die Gerätebibliothek und diese Integration das Modell unterstützen. Aktualisieren Sie die Integration und laden Sie den Eintrag erneut. Falls das Problem bestehen bleibt, melden Sie diese Modell-ID im Issue-Tracker des Projekts."
         }
     },
     "entity": {

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -45,6 +45,12 @@
             "message": "Die Einstellung {field} konnte wegen eines Kommunikationsfehlers mit der Wärmepumpe nicht geschrieben werden."
         }
     },
+    "issues": {
+        "unsupported_controller": {
+            "title": "Nicht unterstütztes Reglermodell",
+            "description": "Das ISG meldet die Reglermodell-ID {model_id}, die von dieser Version der Integration nicht unterstützt wird. Aktualisieren Sie die Integration und laden Sie den Eintrag erneut. Falls das Problem bestehen bleibt, melden Sie diese Modell-ID im Issue-Tracker des Projekts."
+        }
+    },
     "entity": {
         "sensor": {
             "actual_temperature": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -51,7 +51,7 @@
     "issues": {
         "unsupported_controller": {
             "title": "Unsupported controller model",
-            "description": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and try reloading the entry. If the issue remains, report this model ID in the project issue tracker."
+            "description": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. The entry remains unavailable until support is released in the device library and this integration. Update the integration and try reloading the entry. If the issue remains, report this model ID in the project issue tracker."
         }
     },
     "entity": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -48,6 +48,12 @@
             "message": "The setting {field} could not be written because communication with the heat pump failed."
         }
     },
+    "issues": {
+        "unsupported_controller": {
+            "title": "Unsupported controller model",
+            "description": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and try reloading the entry. If the issue remains, report this model ID in the project issue tracker."
+        }
+    },
     "entity": {
         "sensor": {
             "actual_temperature": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -51,7 +51,7 @@
     "issues": {
         "unsupported_controller": {
             "title": "Unsupported controller model",
-            "description": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. The entry remains unavailable until support is released in the device library and this integration. Update the integration and try reloading the entry. If the issue remains, report this model ID in the project issue tracker."
+            "description": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and reload the entry. If it remains unavailable, support has not yet been released in both the device library and this integration; report the model ID in the project issue tracker."
         }
     },
     "entity": {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -219,6 +219,7 @@ async def test_async_setup_entry_unknown_model(
 
     assert result is False
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert not hasattr(mock_config_entry, "runtime_data")
     issue = ir.async_get(hass).async_get_issue(
         DOMAIN, f"unsupported_controller_{mock_config_entry.entry_id}"
     )
@@ -284,6 +285,7 @@ async def test_async_setup_entry_rejects_unhandled_model(
 
     assert result is False
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert not hasattr(mock_config_entry, "runtime_data")
     migrate_device.assert_not_called()
     migrate_entities.assert_not_awaited()
     remove_legacy.assert_not_called()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -226,6 +226,10 @@ async def test_async_setup_entry_unknown_model(
     assert issue.severity is ir.IssueSeverity.ERROR
     assert issue.translation_key == "unsupported_controller"
     assert issue.translation_placeholders == {"model_id": "165"}
+    assert (
+        issue.learn_more_url
+        == "https://github.com/pail23/stiebel_eltron_isg_component/issues"
+    )
 
 
 async def test_supported_model_clears_a_previous_controller_repair(
@@ -255,14 +259,36 @@ async def test_async_setup_entry_rejects_unhandled_model(
     mock_config_entry: MockConfigEntry,
     mock_get_controller_model: MagicMock,
 ) -> None:
-    """A detected model without a coordinator must fail without retries."""
-    mock_get_controller_model.return_value = SimpleNamespace(name="FUTURE")
+    """A detected model without a coordinator must fail with a repair."""
+    mock_get_controller_model.return_value = SimpleNamespace(name="FUTURE", value=166)
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     assert result is False
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    issue = ir.async_get(hass).async_get_issue(
+        DOMAIN, f"unsupported_controller_{mock_config_entry.entry_id}"
+    )
+    assert issue is not None
+    assert issue.translation_placeholders == {"model_id": "166"}
+
+
+async def test_removing_entry_clears_controller_repair(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_get_controller_model: MagicMock,
+) -> None:
+    """Deleting a failed entry must not leave an orphaned repair."""
+    issue_id = f"unsupported_controller_{mock_config_entry.entry_id}"
+    mock_get_controller_model.side_effect = UnknownControllerModelError(165)
+    mock_config_entry.add_to_hass(hass)
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is not None
+
+    await hass.config_entries.async_remove(mock_config_entry.entry_id)
+
+    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None
 
 
 async def test_async_setup_entry_coordinator_update_fails(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -211,6 +211,7 @@ async def test_async_setup_entry_unknown_model(
     mock_modbus_connection: MockModbusConnection,
 ) -> None:
     """Setup fails cleanly (no retry) when the controller model is unknown."""
+    assert mock_modbus_connection.connected is True
     mock_config_entry.add_to_hass(hass)
     mock_get_controller_model.side_effect = UnknownControllerModelError(165)
 
@@ -262,6 +263,7 @@ async def test_async_setup_entry_rejects_unhandled_model(
     mock_modbus_connection: MockModbusConnection,
 ) -> None:
     """A detected model without a coordinator must fail with a repair."""
+    assert mock_modbus_connection.connected is True
     mock_get_controller_model.return_value = SimpleNamespace(name="FUTURE", value=166)
     mock_config_entry.add_to_hass(hass)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from modbus_connection import ModbusError, ModbusTimeoutError
 from modbus_connection.mock import MockModbusConnection
 from pystiebeleltron import (
@@ -205,6 +205,37 @@ async def test_async_setup_entry_unknown_model(
 
     assert result is False
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    issue = ir.async_get(hass).async_get_issue(
+        DOMAIN, f"unsupported_controller_{mock_config_entry.entry_id}"
+    )
+    assert issue is not None
+    assert issue.issue_domain == DOMAIN
+    assert issue.is_fixable is False
+    assert issue.severity is ir.IssueSeverity.ERROR
+    assert issue.translation_key == "unsupported_controller"
+    assert issue.translation_placeholders == {"model_id": "165"}
+
+
+async def test_supported_model_clears_a_previous_controller_repair(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A library update that recognizes the model resolves the repair."""
+    issue_id = f"unsupported_controller_{mock_config_entry.entry_id}"
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="unsupported_controller",
+        translation_placeholders={"model_id": "165"},
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None
 
 
 async def test_async_setup_entry_rejects_unhandled_model(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -175,6 +175,12 @@ async def test_async_setup_entry_cannot_connect(
 
     assert result is False
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert (
+        ir.async_get(hass).async_get_issue(
+            DOMAIN, f"unsupported_controller_{mock_config_entry.entry_id}"
+        )
+        is None
+    )
 
 
 async def test_async_setup_entry_modbus_error(
@@ -190,6 +196,12 @@ async def test_async_setup_entry_modbus_error(
 
     assert result is False
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert (
+        ir.async_get(hass).async_get_issue(
+            DOMAIN, f"unsupported_controller_{mock_config_entry.entry_id}"
+        )
+        is None
+    )
 
 
 async def test_async_setup_entry_unknown_model(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -208,6 +208,7 @@ async def test_async_setup_entry_unknown_model(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_get_controller_model: MagicMock,
+    mock_modbus_connection: MockModbusConnection,
 ) -> None:
     """Setup fails cleanly (no retry) when the controller model is unknown."""
     mock_config_entry.add_to_hass(hass)
@@ -221,7 +222,6 @@ async def test_async_setup_entry_unknown_model(
         DOMAIN, f"unsupported_controller_{mock_config_entry.entry_id}"
     )
     assert issue is not None
-    assert issue.issue_domain == DOMAIN
     assert issue.is_fixable is False
     assert issue.severity is ir.IssueSeverity.ERROR
     assert issue.translation_key == "unsupported_controller"
@@ -230,6 +230,7 @@ async def test_async_setup_entry_unknown_model(
         issue.learn_more_url
         == "https://github.com/pail23/stiebel_eltron_isg_component/issues"
     )
+    assert mock_modbus_connection.connected is False
 
 
 async def test_supported_model_clears_a_previous_controller_repair(
@@ -258,20 +259,38 @@ async def test_async_setup_entry_rejects_unhandled_model(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_get_controller_model: MagicMock,
+    mock_modbus_connection: MockModbusConnection,
 ) -> None:
     """A detected model without a coordinator must fail with a repair."""
     mock_get_controller_model.return_value = SimpleNamespace(name="FUTURE", value=166)
     mock_config_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    with (
+        patch(
+            "custom_components.stiebel_eltron_isg.async_migrate_device_identifier"
+        ) as migrate_device,
+        patch(
+            "custom_components.stiebel_eltron_isg.async_migrate_unique_ids",
+            new_callable=AsyncMock,
+        ) as migrate_entities,
+        patch(
+            "custom_components.stiebel_eltron_isg."
+            "async_remove_legacy_circulation_pump_switch"
+        ) as remove_legacy,
+    ):
+        result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     assert result is False
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    migrate_device.assert_not_called()
+    migrate_entities.assert_not_awaited()
+    remove_legacy.assert_not_called()
     issue = ir.async_get(hass).async_get_issue(
         DOMAIN, f"unsupported_controller_{mock_config_entry.entry_id}"
     )
     assert issue is not None
     assert issue.translation_placeholders == {"model_id": "166"}
+    assert mock_modbus_connection.connected is False
 
 
 async def test_removing_entry_clears_controller_repair(

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -24,6 +24,7 @@ other means one of them is stale, so both directions are compared as well.
 
 import json
 import pathlib
+from string import Formatter
 from types import ModuleType
 
 from homeassistant.helpers.entity import EntityDescription
@@ -164,6 +165,28 @@ def test_english_repair_issues_match_strings() -> None:
     english = json.loads(_RUNTIME_FILE.read_text(encoding="utf-8"))["issues"]
 
     assert _key_tree(english) == _key_tree(strings)
+
+
+@pytest.mark.parametrize(
+    "translation_file",
+    [_STRINGS_FILE, _RUNTIME_FILE, _TRANSLATIONS_DIR / "de.json"],
+    ids=lambda file: file.name,
+)
+def test_controller_repair_uses_model_id_placeholder(
+    translation_file: pathlib.Path,
+) -> None:
+    """Every shipped repair text must preserve its runtime placeholder."""
+    issue = json.loads(translation_file.read_text(encoding="utf-8"))["issues"][
+        "unsupported_controller"
+    ]
+    placeholders = {
+        field
+        for text in issue.values()
+        for _, field, _, _ in Formatter().parse(text)
+        if field is not None
+    }
+
+    assert placeholders == {"model_id"}
 
 
 def test_config_flow_strings_match_runtime_fields() -> None:

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -158,6 +158,14 @@ def test_english_config_flow_matches_strings() -> None:
     assert _key_tree(english) == _key_tree(strings)
 
 
+def test_english_repair_issues_match_strings() -> None:
+    """Runtime repair translations must carry every declared field."""
+    strings = json.loads(_STRINGS_FILE.read_text(encoding="utf-8"))["issues"]
+    english = json.loads(_RUNTIME_FILE.read_text(encoding="utf-8"))["issues"]
+
+    assert _key_tree(english) == _key_tree(strings)
+
+
 def test_config_flow_strings_match_runtime_fields() -> None:
     """Config-flow strings must describe the fields and forms users can open."""
     steps = json.loads(_STRINGS_FILE.read_text(encoding="utf-8"))["config"]["step"]

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -51,6 +51,16 @@ _TRANSLATIONS_DIR = _COMPONENT_DIR / "translations"
 _RUNTIME_FILE = _TRANSLATIONS_DIR / "en.json"
 
 
+def _repair_translation_files() -> list[pathlib.Path]:
+    """Return source and runtime files that ship repair text."""
+    runtime_files = [
+        file
+        for file in sorted(_TRANSLATIONS_DIR.glob("*.json"))
+        if "issues" in json.loads(file.read_text(encoding="utf-8"))
+    ]
+    return [_STRINGS_FILE, *runtime_files]
+
+
 def _platform(module: ModuleType) -> str:
     """Return the platform domain a module provides entities for."""
     return module.__name__.rsplit(".", 1)[-1]
@@ -169,7 +179,7 @@ def test_english_repair_issues_match_strings() -> None:
 
 @pytest.mark.parametrize(
     "translation_file",
-    [_STRINGS_FILE, _RUNTIME_FILE, _TRANSLATIONS_DIR / "de.json"],
+    _repair_translation_files(),
     ids=lambda file: file.name,
 )
 def test_controller_repair_uses_model_id_placeholder(

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -51,14 +51,18 @@ _TRANSLATIONS_DIR = _COMPONENT_DIR / "translations"
 _RUNTIME_FILE = _TRANSLATIONS_DIR / "en.json"
 
 
-def _repair_translation_files() -> list[pathlib.Path]:
-    """Return source and runtime files that ship repair text."""
-    runtime_files = [
+def _runtime_repair_translation_files() -> list[pathlib.Path]:
+    """Return runtime files that ship repair text."""
+    return [
         file
         for file in sorted(_TRANSLATIONS_DIR.glob("*.json"))
         if "issues" in json.loads(file.read_text(encoding="utf-8"))
     ]
-    return [_STRINGS_FILE, *runtime_files]
+
+
+def _repair_translation_files() -> list[pathlib.Path]:
+    """Return source and runtime files that ship repair text."""
+    return [_STRINGS_FILE, *_runtime_repair_translation_files()]
 
 
 def _platform(module: ModuleType) -> str:
@@ -169,12 +173,19 @@ def test_english_config_flow_matches_strings() -> None:
     assert _key_tree(english) == _key_tree(strings)
 
 
-def test_english_repair_issues_match_strings() -> None:
-    """Runtime repair translations must carry every declared field."""
+@pytest.mark.parametrize(
+    "translation_file",
+    _runtime_repair_translation_files(),
+    ids=lambda file: file.name,
+)
+def test_runtime_repair_issues_match_strings(
+    translation_file: pathlib.Path,
+) -> None:
+    """Every runtime file with repair text must carry each declared field."""
     strings = json.loads(_STRINGS_FILE.read_text(encoding="utf-8"))["issues"]
-    english = json.loads(_RUNTIME_FILE.read_text(encoding="utf-8"))["issues"]
+    runtime = json.loads(translation_file.read_text(encoding="utf-8"))["issues"]
 
-    assert _key_tree(english) == _key_tree(strings)
+    assert _key_tree(runtime) == _key_tree(strings)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Independent of the other open PRs, based on `main`.

An unsupported controller currently ends in a setup error that Home Assistant retries forever.
The log line naming the model scrolls away, the user sees an entry that keeps failing without saying why, and we get an issue report without the one number that would identify the device.

## Changes

One Repair issue per config entry, in two cases:

- The controller returns a raw model ID the library does not know.
- The library recognises the model, but the integration has no dispatch for it yet.

The Repair carries the model ID and a link to the issue tracker, so the report we need is one copy away.
Both cases raise a permanent setup error instead of a retry, because retrying a wrong model never succeeds.

Transient failures are kept strictly apart.
A connection failure or a failed model read is still a setup retry and never creates the Repair, so a device that is briefly offline does not leave a permanent issue behind.

## Clearing the Repair

- When support for the model becomes available and setup reaches a supported coordinator, the issue is cleared.
- When the config entry is deleted, its issue is cleared with it.

On the unsupported paths the existing failed-setup cleanup closes the Modbus connection, and the tests now lock that behavior down.
No registry migration runs.
Migrating the entity registry for a model whose entity layout is unknown would write entries that may never be correct.

## Tests

- Both unsupported cases raise the permanent error and create the issue; the transient cases do not.
- Both clearing paths, connection cleanup, and the absence of registry migrations on unsupported paths.
- Every runtime translation that ships Repair text carries the complete source key tree, and every source or runtime Repair keeps the `{model_id}` placeholder.

## Verification

- 757 passed, one expected skip
- `ruff check` and `ruff format --check` clean
- `mypy` clean

Part of #629.

## Summary by Sourcery

Handle unsupported controller models via Home Assistant Repairs instead of endless setup retries.

Bug Fixes:
- Stop retrying setup indefinitely for controllers with unknown or unhandled models and surface a clear repair issue instead.

Enhancements:
- Create a non-fixable Repair issue per config entry for unsupported controllers, including the model identifier and link to the issue tracker.
- Clear the associated Repair issue when a previously unsupported controller model becomes supported or its config entry is removed.
- Avoid running registry migrations and close the Modbus connection when the controller model is unsupported.

Tests:
- Extend tests to cover unsupported controller repair creation, clearing on successful setup or entry removal, and to ensure transient failures never create repairs.
- Add translation tests to validate repair issue keys and enforce the presence of the model_id placeholder across source and runtime translations.
