### PR TITLE
Skip writes that would not change a value

### DIFF
--- a/custom_components/stiebel_eltron_isg/climate.py
+++ b/custom_components/stiebel_eltron_isg/climate.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+import math
 from typing import Any
 
 from homeassistant.components.climate import ClimateEntity, ClimateEntityDescription
@@ -420,10 +421,15 @@ class StiebelEltronISGClimateEntity(
         """Set new target temperature."""
         value = kwargs["temperature"]
         field = self._target_temp_write_field
-        if field is not None:
-            await self._write_field(field, value)
-            self._optimistic_target_field = field
-            self._set_optimistic_value(value)
+        current = self.target_temperature
+        if field is None:
+            return
+        if current is not None and math.isclose(current, value, abs_tol=1e-9):
+            return
+
+        await self._write_field(field, value)
+        self._optimistic_target_field = field
+        self._set_optimistic_value(value)
 
     def _read_accessor(self, accessor: Any) -> float | int | None:
         """Read a value via accessor callable."""
@@ -477,7 +483,7 @@ class StiebelEltronWPMClimateEntity(StiebelEltronISGClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new operation mode."""
         new_mode = HA_TO_WPM_HVAC.get(hvac_mode)
-        if new_mode is not None:
+        if new_mode is not None and self.operation_mode != new_mode:
             await self._write_field("operating_mode", new_mode)
 
     @property
@@ -488,7 +494,7 @@ class StiebelEltronWPMClimateEntity(StiebelEltronISGClimateEntity):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new target preset mode."""
         new_mode = HA_TO_WPM_PRESET.get(preset_mode)
-        if new_mode is not None:
+        if new_mode is not None and self.operation_mode != new_mode:
             await self._write_field("operating_mode", new_mode)
 
 
@@ -530,7 +536,7 @@ class StiebelEltronLWZClimateEntity(StiebelEltronISGClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new operation mode."""
         new_mode = HA_TO_LWZ_HVAC.get(hvac_mode)
-        if new_mode is not None:
+        if new_mode is not None and self.operation_mode != new_mode:
             await self._write_field("operating_mode", new_mode)
 
     @property
@@ -541,7 +547,7 @@ class StiebelEltronLWZClimateEntity(StiebelEltronISGClimateEntity):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new target preset mode."""
         new_mode = HA_TO_LWZ_PRESET.get(preset_mode)
-        if new_mode is not None:
+        if new_mode is not None and self.operation_mode != new_mode:
             await self._write_field("operating_mode", new_mode)
 
     @property
@@ -560,7 +566,7 @@ class StiebelEltronLWZClimateEntity(StiebelEltronISGClimateEntity):
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         new_mode = HA_TO_LWZ_FAN.get(fan_mode)
-        if new_mode is not None:
+        if new_mode is not None and self.fan_mode != fan_mode:
             if self.operation_mode == ECO_MODE:
                 await self._write_field("night_stage", new_mode)
             else:

--- a/custom_components/stiebel_eltron_isg/climate.py
+++ b/custom_components/stiebel_eltron_isg/climate.py
@@ -374,6 +374,12 @@ class StiebelEltronISGClimateEntity(
         raise NotImplementedError
 
     @property
+    def _raw_operation_mode(self) -> int | None:
+        """Return the raw mode while preserving an unavailable read-back."""
+        value = self._read_register(lambda api: api.system_parameters.operating_mode)
+        return int(value) if value is not None else None
+
+    @property
     def current_humidity(self) -> int | None:
         """Return the current humidity."""
         for accessor in self.humidity_modbus_register:
@@ -421,9 +427,9 @@ class StiebelEltronISGClimateEntity(
         """Set new target temperature."""
         value = kwargs["temperature"]
         field = self._target_temp_write_field
-        current = self.target_temperature
         if field is None:
             return
+        current = self.target_temperature
         if current is not None and math.isclose(current, value, abs_tol=1e-9):
             return
 
@@ -472,8 +478,8 @@ class StiebelEltronWPMClimateEntity(StiebelEltronISGClimateEntity):
     @property
     def operation_mode(self) -> int:
         """Operating mode of the heat pump."""
-        value = self._read_register(lambda api: api.system_parameters.operating_mode)
-        return int(value) if value is not None else 0
+        raw_mode = self._raw_operation_mode
+        return raw_mode if raw_mode is not None else 0
 
     @property
     def hvac_mode(self) -> HVACMode | None:
@@ -483,7 +489,8 @@ class StiebelEltronWPMClimateEntity(StiebelEltronISGClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new operation mode."""
         new_mode = HA_TO_WPM_HVAC.get(hvac_mode)
-        if new_mode is not None and self.operation_mode != new_mode:
+        # Several raw modes map to AUTO, so compare the controller value.
+        if new_mode is not None and self._raw_operation_mode != new_mode:
             await self._write_field("operating_mode", new_mode)
 
     @property
@@ -494,7 +501,7 @@ class StiebelEltronWPMClimateEntity(StiebelEltronISGClimateEntity):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new target preset mode."""
         new_mode = HA_TO_WPM_PRESET.get(preset_mode)
-        if new_mode is not None and self.operation_mode != new_mode:
+        if new_mode is not None and self._raw_operation_mode != new_mode:
             await self._write_field("operating_mode", new_mode)
 
 
@@ -525,8 +532,8 @@ class StiebelEltronLWZClimateEntity(StiebelEltronISGClimateEntity):
     @property
     def operation_mode(self) -> int:
         """Operating mode of the heat pump."""
-        value = self._read_register(lambda api: api.system_parameters.operating_mode)
-        return int(value) if value is not None else 0
+        raw_mode = self._raw_operation_mode
+        return raw_mode if raw_mode is not None else 0
 
     @property
     def hvac_mode(self) -> HVACMode | None:
@@ -536,7 +543,8 @@ class StiebelEltronLWZClimateEntity(StiebelEltronISGClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new operation mode."""
         new_mode = HA_TO_LWZ_HVAC.get(hvac_mode)
-        if new_mode is not None and self.operation_mode != new_mode:
+        # Several raw modes map to AUTO, so compare the controller value.
+        if new_mode is not None and self._raw_operation_mode != new_mode:
             await self._write_field("operating_mode", new_mode)
 
     @property
@@ -547,7 +555,7 @@ class StiebelEltronLWZClimateEntity(StiebelEltronISGClimateEntity):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new target preset mode."""
         new_mode = HA_TO_LWZ_PRESET.get(preset_mode)
-        if new_mode is not None and self.operation_mode != new_mode:
+        if new_mode is not None and self._raw_operation_mode != new_mode:
             await self._write_field("operating_mode", new_mode)
 
     @property

--- a/custom_components/stiebel_eltron_isg/select.py
+++ b/custom_components/stiebel_eltron_isg/select.py
@@ -160,10 +160,12 @@ class StiebelEltronISGSelectEntity(
     async def async_select_option(self, option: str) -> None:
         """Update the current selected option."""
         key = get_key_from_value(self._options, option)
-        if key is not None and self.write_field is not None:
-            await self.coordinator.write_component_value(
-                self.write_component,
-                self.write_field,
-                key,
-            )
-            self._set_optimistic_value(key)
+        if key is None or self.write_field is None or self.current_option == option:
+            return
+
+        await self.coordinator.write_component_value(
+            self.write_component,
+            self.write_field,
+            key,
+        )
+        self._set_optimistic_value(key)

--- a/custom_components/stiebel_eltron_isg/switch.py
+++ b/custom_components/stiebel_eltron_isg/switch.py
@@ -113,25 +113,25 @@ class StiebelEltronISGSwitch(StiebelEltronISGEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        if self.write_component is None or self.write_field is None:
-            return
-
-        await self.coordinator.write_component_value(
-            self.write_component,
-            self.write_field,
-            1,
-        )
-        await self.async_update()
+        await self._async_set_state(1)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
+        await self._async_set_state(0)
+
+    async def _async_set_state(self, value: int) -> None:
+        """Write a changed switch state and refresh its read-back value."""
         if self.write_component is None or self.write_field is None:
+            return
+
+        current = self.coordinator.get_value(self.modbus_register)
+        if current is not None and (current != 0) == (value != 0):
             return
 
         await self.coordinator.write_component_value(
             self.write_component,
             self.write_field,
-            0,
+            value,
         )
         await self.async_update()
 

--- a/custom_components/stiebel_eltron_isg/switch.py
+++ b/custom_components/stiebel_eltron_isg/switch.py
@@ -125,7 +125,7 @@ class StiebelEltronISGSwitch(StiebelEltronISGEntity, SwitchEntity):
             return
 
         current = self.coordinator.get_value(self.modbus_register)
-        if current is not None and (current != 0) == (value != 0):
+        if current is not None and bool(current) == bool(value):
             return
 
         await self.coordinator.write_component_value(

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -226,6 +226,34 @@ async def test_wpm_hvac_and_preset_mapping() -> None:
     ]
 
 
+async def test_wpm_skips_unchanged_hvac_mode() -> None:
+    """Setting the raw operating mode again through HVAC must not write."""
+    entity = _make_wpm_climate(operating_mode=5)
+
+    await entity.async_set_hvac_mode(HVACMode.OFF)
+
+    assert entity.coordinator.writes == []
+
+
+async def test_wpm_skips_unchanged_preset_mode() -> None:
+    """Setting the reported preset again must not write its operating mode."""
+    entity = _make_wpm_climate(operating_mode=3)
+
+    await entity.async_set_preset_mode("comfort")
+
+    assert entity.coordinator.writes == []
+
+
+async def test_wpm_hvac_compares_raw_mode_not_mapped_auto_state() -> None:
+    """AUTO must still select program when another raw AUTO mode is active."""
+    entity = _make_wpm_climate(operating_mode=1)
+    assert entity.hvac_mode is HVACMode.AUTO
+
+    await entity.async_set_hvac_mode(HVACMode.AUTO)
+
+    assert entity.coordinator.writes == [("system_parameters", "operating_mode", 2)]
+
+
 async def test_lwz_hvac_and_preset_mapping() -> None:
     """LWZ exposes and writes Home Assistant modes through its mapping."""
     entity = _make_lwz_climate(operating_mode=1)
@@ -240,6 +268,24 @@ async def test_lwz_hvac_and_preset_mapping() -> None:
         ("system_parameters", "operating_mode", 5),
         ("system_parameters", "operating_mode", 14),
     ]
+
+
+async def test_lwz_skips_unchanged_hvac_mode() -> None:
+    """Setting the raw operating mode again through HVAC must not write."""
+    entity = _make_lwz_climate(operating_mode=5)
+
+    await entity.async_set_hvac_mode(HVACMode.OFF)
+
+    assert entity.coordinator.writes == []
+
+
+async def test_lwz_skips_unchanged_preset_mode() -> None:
+    """Setting the reported preset again must not write its operating mode."""
+    entity = _make_lwz_climate(operating_mode=14)
+
+    await entity.async_set_preset_mode("manual")
+
+    assert entity.coordinator.writes == []
 
 
 @pytest.mark.parametrize("operating_mode", [ECO_MODE, 3])
@@ -287,7 +333,7 @@ def test_lwz_fan_mode_uses_day_stage_when_not_eco() -> None:
 
 async def test_lwz_set_fan_mode_writes_night_stage_when_eco() -> None:
     """Setting the fan mode in eco mode must write the night stage field."""
-    entity = _make_lwz_climate(operating_mode=ECO_MODE)
+    entity = _make_lwz_climate(operating_mode=ECO_MODE, night_stage=2)
 
     await entity.async_set_fan_mode(FAN_LOW)
 
@@ -296,11 +342,32 @@ async def test_lwz_set_fan_mode_writes_night_stage_when_eco() -> None:
 
 async def test_lwz_set_fan_mode_writes_day_stage_when_not_eco() -> None:
     """Setting the fan mode outside eco mode must write the day stage field."""
-    entity = _make_lwz_climate(operating_mode=3)
+    entity = _make_lwz_climate(operating_mode=3, day_stage=1)
 
     await entity.async_set_fan_mode(FAN_HIGH)
 
     assert entity.coordinator.writes == [("system_parameters", "day_stage", 3)]
+
+
+@pytest.mark.parametrize(
+    ("operating_mode", "day_stage", "night_stage", "fan_mode"),
+    [
+        (3, 3, 1, FAN_HIGH),
+        (ECO_MODE, 3, 1, FAN_LOW),
+    ],
+)
+async def test_lwz_skips_unchanged_fan_mode(
+    operating_mode: int,
+    day_stage: int,
+    night_stage: int,
+    fan_mode: str,
+) -> None:
+    """Setting the active fan stage again must not issue a Modbus write."""
+    entity = _make_lwz_climate(operating_mode, day_stage, night_stage)
+
+    await entity.async_set_fan_mode(fan_mode)
+
+    assert entity.coordinator.writes == []
 
 
 async def test_climate_shows_written_target_before_the_next_poll() -> None:
@@ -314,6 +381,28 @@ async def test_climate_shows_written_target_before_the_next_poll() -> None:
     ]
     assert entity.target_temperature == 22.5
     assert entity.published_states == 1
+
+
+async def test_climate_skips_write_when_target_is_unchanged() -> None:
+    """Setting the reported target again must not issue a Modbus write."""
+    entity = _make_lwz_climate(operating_mode=3)
+
+    await entity.async_set_temperature(temperature=21.0)
+
+    assert entity.coordinator.writes == []
+    assert entity.published_states == 0
+
+
+async def test_climate_skips_float_imprecise_unchanged_target() -> None:
+    """A decoded float equal to the requested target must not be rewritten."""
+    entity = _make_lwz_climate(operating_mode=3)
+    decoded = 71 * 0.1
+    assert decoded != 7.1
+    entity.coordinator._api.system_parameters.room_temperature_day_hk1 = decoded
+
+    await entity.async_set_temperature(temperature=7.1)
+
+    assert entity.coordinator.writes == []
 
 
 async def test_climate_does_not_assume_a_target_when_the_write_fails() -> None:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -399,6 +399,15 @@ async def test_lwz_writes_fan_mode_when_stage_is_unknown() -> None:
     assert entity.coordinator.writes == [("system_parameters", "night_stage", 1)]
 
 
+async def test_lwz_writes_fan_mode_when_day_stage_is_unknown() -> None:
+    """An unknown day stage outside eco mode must not suppress a valid write."""
+    entity = _make_lwz_climate(operating_mode=3, day_stage=None)
+
+    await entity.async_set_fan_mode(FAN_LOW)
+
+    assert entity.coordinator.writes == [("system_parameters", "day_stage", 1)]
+
+
 async def test_climate_shows_written_target_before_the_next_poll() -> None:
     """A written target must be reported at once, not only after the next poll."""
     entity = _make_lwz_climate(operating_mode=3)
@@ -420,6 +429,20 @@ async def test_climate_skips_write_when_target_is_unchanged() -> None:
 
     assert entity.coordinator.writes == []
     assert entity.published_states == 0
+
+
+async def test_climate_writes_when_target_is_unknown() -> None:
+    """An unknown target must not suppress a valid temperature write."""
+    entity = _make_lwz_climate(operating_mode=3)
+    entity.coordinator._api.system_parameters.room_temperature_day_hk1 = None
+
+    await entity.async_set_temperature(temperature=21.0)
+
+    assert entity.coordinator.writes == [
+        ("system_parameters", "room_temperature_day_hk1", 21.0)
+    ]
+    assert entity.target_temperature == 21.0
+    assert entity.published_states == 1
 
 
 async def test_climate_skips_float_imprecise_unchanged_target() -> None:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -84,7 +84,9 @@ class _StubCoordinator:
 
 
 def _make_lwz_climate(
-    operating_mode: int, day_stage: int = 3, night_stage: int = 1
+    operating_mode: int | None,
+    day_stage: int | None = 3,
+    night_stage: int | None = 1,
 ) -> StiebelEltronLWZClimateEntity:
     entity = StiebelEltronLWZClimateEntity.__new__(StiebelEltronLWZClimateEntity)
     api = _FakeApi(_FakeSystemParameters(operating_mode, day_stage, night_stage))
@@ -108,7 +110,7 @@ def _make_lwz_climate(
     return entity
 
 
-def _make_wpm_climate(operating_mode: int) -> StiebelEltronWPMClimateEntity:
+def _make_wpm_climate(operating_mode: int | None) -> StiebelEltronWPMClimateEntity:
     """Build a minimal WPM climate entity."""
     entity = StiebelEltronWPMClimateEntity.__new__(StiebelEltronWPMClimateEntity)
     api = _FakeApi(_FakeSystemParameters(operating_mode, 3, 1))
@@ -244,6 +246,15 @@ async def test_wpm_skips_unchanged_preset_mode() -> None:
     assert entity.coordinator.writes == []
 
 
+async def test_wpm_writes_emergency_when_operating_mode_is_unknown() -> None:
+    """An unknown raw mode must not suppress an emergency-mode write."""
+    entity = _make_wpm_climate(operating_mode=None)
+
+    await entity.async_set_preset_mode("emergency")
+
+    assert entity.coordinator.writes == [("system_parameters", "operating_mode", 0)]
+
+
 async def test_wpm_hvac_compares_raw_mode_not_mapped_auto_state() -> None:
     """AUTO must still select program when another raw AUTO mode is active."""
     entity = _make_wpm_climate(operating_mode=1)
@@ -286,6 +297,15 @@ async def test_lwz_skips_unchanged_preset_mode() -> None:
     await entity.async_set_preset_mode("manual")
 
     assert entity.coordinator.writes == []
+
+
+async def test_lwz_writes_emergency_when_operating_mode_is_unknown() -> None:
+    """An unknown raw mode must not suppress an emergency-mode write."""
+    entity = _make_lwz_climate(operating_mode=None)
+
+    await entity.async_set_preset_mode("emergency")
+
+    assert entity.coordinator.writes == [("system_parameters", "operating_mode", 0)]
 
 
 @pytest.mark.parametrize("operating_mode", [ECO_MODE, 3])
@@ -368,6 +388,15 @@ async def test_lwz_skips_unchanged_fan_mode(
     await entity.async_set_fan_mode(fan_mode)
 
     assert entity.coordinator.writes == []
+
+
+async def test_lwz_writes_fan_mode_when_stage_is_unknown() -> None:
+    """An unknown active fan stage must not suppress a valid write."""
+    entity = _make_lwz_climate(operating_mode=ECO_MODE, night_stage=None)
+
+    await entity.async_set_fan_mode(FAN_LOW)
+
+    assert entity.coordinator.writes == [("system_parameters", "night_stage", 1)]
 
 
 async def test_climate_shows_written_target_before_the_next_poll() -> None:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -61,6 +61,7 @@ async def test_select_writes_when_current_option_is_unknown() -> None:
     await entity.async_select_option("comfort")
 
     assert entity.coordinator.writes == [("system_parameters", "operating_mode", 2)]
+    assert entity.current_option == "comfort"
 
 
 async def test_select_shows_written_option_before_the_next_poll() -> None:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -45,6 +45,15 @@ async def test_select_writes_the_key_of_the_option() -> None:
     assert entity.coordinator.writes == [("system_parameters", "operating_mode", 2)]
 
 
+async def test_select_skips_write_when_option_is_unchanged() -> None:
+    """Selecting the reported option again must not issue a Modbus write."""
+    entity = _make_select(current=2)
+
+    await entity.async_select_option("comfort")
+
+    assert entity.coordinator.writes == []
+
+
 async def test_select_shows_written_option_before_the_next_poll() -> None:
     """A selected option must be reported at once, not only after the next poll."""
     entity = _make_select(current=0)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -54,6 +54,15 @@ async def test_select_skips_write_when_option_is_unchanged() -> None:
     assert entity.coordinator.writes == []
 
 
+async def test_select_writes_when_current_option_is_unknown() -> None:
+    """An unknown read-back must not suppress a valid option write."""
+    entity = _make_select(current=None)
+
+    await entity.async_select_option("comfort")
+
+    assert entity.coordinator.writes == [("system_parameters", "operating_mode", 2)]
+
+
 async def test_select_shows_written_option_before_the_next_poll() -> None:
     """A selected option must be reported at once, not only after the next poll."""
     entity = _make_select(current=0)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -70,13 +70,60 @@ async def test_switch_action_writes_and_updates(method: str, value: int) -> None
     entity = StiebelEltronISGSwitch.__new__(StiebelEltronISGSwitch)
     entity.write_component = "settings"
     entity.write_field = "enabled"
-    entity.coordinator = SimpleNamespace(write_component_value=AsyncMock())
+    entity.modbus_register = lambda api: api.value
+    entity.coordinator = SimpleNamespace(
+        get_value=lambda accessor: accessor(SimpleNamespace(value=1 - value)),
+        write_component_value=AsyncMock(),
+    )
     entity.async_update = AsyncMock()
 
     await getattr(entity, method)()
 
     entity.coordinator.write_component_value.assert_awaited_once_with(
         "settings", "enabled", value
+    )
+    entity.async_update.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("method", "value"), [("async_turn_on", 1), ("async_turn_off", 0)]
+)
+async def test_switch_skips_write_when_state_is_unchanged(
+    method: str, value: int
+) -> None:
+    """Setting a known switch state again must not issue a Modbus write."""
+    entity = StiebelEltronISGSwitch.__new__(StiebelEltronISGSwitch)
+    entity.write_component = "settings"
+    entity.write_field = "enabled"
+    entity.modbus_register = lambda api: api.value
+    entity.coordinator = SimpleNamespace(
+        get_value=lambda accessor: accessor(SimpleNamespace(value=value)),
+        write_component_value=AsyncMock(),
+    )
+    entity.async_update = AsyncMock()
+
+    await getattr(entity, method)()
+
+    entity.coordinator.write_component_value.assert_not_awaited()
+    entity.async_update.assert_not_awaited()
+
+
+async def test_switch_writes_when_read_back_is_unknown() -> None:
+    """An unknown read-back must not be mistaken for the off state."""
+    entity = StiebelEltronISGSwitch.__new__(StiebelEltronISGSwitch)
+    entity.write_component = "settings"
+    entity.write_field = "enabled"
+    entity.modbus_register = lambda api: api.value
+    entity.coordinator = SimpleNamespace(
+        get_value=lambda accessor: accessor(SimpleNamespace(value=None)),
+        write_component_value=AsyncMock(),
+    )
+    entity.async_update = AsyncMock()
+
+    await entity.async_turn_off()
+
+    entity.coordinator.write_component_value.assert_awaited_once_with(
+        "settings", "enabled", 0
     )
     entity.async_update.assert_awaited_once()
 


### PR DESCRIPTION
Independent of the other open PRs, based on `main`.

Every service call from Home Assistant reached the controller as a Modbus write, even when the requested value was the one already there.
Re-running a scene, an automation that sets a fixed target on every trigger, or simply tapping the mode a card already shows produced a write that could not change anything.
The reason to avoid this is narrow: it is redundant Modbus traffic and unnecessary service work on the write path.

## Changes

- Climate, select and switch entities compare the requested value against the current read-back before writing and return without a write when they match.
- Comparisons only skip a write when the current value is actually known.
  An unknown read-back still writes, so a missing value is never mistaken for agreement, and the SG Ready switches keep working while the device reports nothing.
- Climate mode comparisons use the raw controller mode, not the mapped Home Assistant state.
  Several raw modes map to `AUTO`, so comparing the mapped state would swallow a real mode change.
  Preserving an unavailable raw mode separately also matters because the display fallback `0` is the emergency mode; treating a missing read-back as `0` would suppress a valid emergency write.
- Target temperatures compare with `math.isclose`.
  A decoded register value such as `71 * 0.1` is not exactly `7.1`, and an exact comparison would rewrite it on every call.
- The switch compares against the last coordinator snapshot.
  Between two polls that value can be stale, so a change made at the controller in that window is not written back until the next poll refreshes it.
  That tradeoff is the same one the entity state already carries.

## Tests

New tests per platform cover the unchanged case, the unknown-read-back case, the raw-mode case that must still write, and the float case.
The existing tests that write were adjusted to start from a different value so they still exercise the write path.

## Verification

- 769 tests passed, one expected skip for the library field without a range validator.
- `ruff check` and `ruff format --check` clean.
- `mypy` clean.

No live writes against a heat pump were performed for this change.

Part of #629.
