### PR TITLE
Report duplicate entities left by the 2026.7 unique-ID migration as a fixable Repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,17 +198,17 @@ For users:
 
 1. Update the integration and restart Home Assistant.
 2. If entities show as unavailable, reload the integration once from the UI.
-3. Some entities were renamed in the refactoring. If you end up with unavailable
-   leftovers, remove those entities individually, or delete the integration entry and
-   add it again for a completely clean set.
+3. Some installations briefly created replacement entities during the unique-ID transition.
+   If Home Assistant reports unavailable duplicates, open the Repair and review the exact entity IDs before confirming their removal.
+   If the Repair is not available, remove only an unavailable leftover that has a working counterpart and is no longer referenced by a dashboard or automation.
+   Removing and adding the integration again is not the preferred cleanup because it can change entity IDs and require references to be updated.
 
 A note on history, because it is easy to get wrong in both directions. Removing an
 entity does not delete its recorded history: the long term statistics stay behind
 under the old entity id and show up in Developer Tools, Statistics as no longer
-provided, where you can delete them deliberately. What does not happen
-automatically is linking them to a differently named replacement. Renaming an entity
-inside Home Assistant is the one path that carries its statistics along, because the
-recorder migrates the statistic id on a rename but has no hook for a removal.
+provided, where you can delete them deliberately.
+Home Assistant does not merge that separate series into the working entity automatically.
+Renaming an entity inside Home Assistant is the one path that carries its statistics along, because the recorder migrates the statistic id on a rename but has no hook for a removal.
 
 To change the IP address or port of the ISG, use **Reconfigure** in the three-dot
 menu of the integration entry. It leaves the entities untouched, so nothing has to be

--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -27,6 +27,7 @@ from .migration import (
     async_migrate_device_identifier,
     async_migrate_unique_ids,
     async_remove_legacy_circulation_pump_switch,
+    duplicate_entity_issue_id,
 )
 from .wpm3i_coordinator import StiebelEltronModbusWPM3iDataCoordinator
 from .wpm_coordinator import StiebelEltronModbusWPMDataCoordinator
@@ -173,3 +174,4 @@ async def async_remove_entry(
 ) -> None:
     """Remove repairs that belong to a deleted config entry."""
     ir.async_delete_issue(hass, DOMAIN, _unsupported_controller_issue_id(entry))
+    ir.async_delete_issue(hass, DOMAIN, duplicate_entity_issue_id(entry))

--- a/custom_components/stiebel_eltron_isg/migration.py
+++ b/custom_components/stiebel_eltron_isg/migration.py
@@ -16,7 +16,11 @@ from typing import Any
 
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from pystiebeleltron import ControllerModel
 
 from .const import CIRCULATION_PUMP, DOMAIN, HEATER_PRESSURE
@@ -31,6 +35,11 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 # entity would be migrated to an id that no entity description produces and stay
 # orphaned for the second time.
 _RENAMED_KEYS = {"heating_pressure": HEATER_PRESSURE}
+
+
+def duplicate_entity_issue_id(entry: StiebelEltronConfigEntry) -> str:
+    """Return the stable duplicate-entity Repair id for a config entry."""
+    return f"duplicate_entities_{entry.entry_id}"
 
 
 @callback
@@ -163,6 +172,53 @@ def _plan_migration(
 
 
 @callback
+def async_get_duplicate_entities(
+    hass: HomeAssistant,
+    entry: StiebelEltronConfigEntry,
+    model: ControllerModel,
+) -> list[er.RegistryEntry]:
+    """Return registry entries that still lose a unique-id collision."""
+    entries = er.async_entries_for_config_entry(er.async_get(hass), entry.entry_id)
+    _, losers = _plan_migration(
+        entries,
+        _legacy_prefixes(entry, model),
+        build_unique_id(entry, ""),
+    )
+    return losers
+
+
+@callback
+def async_sync_duplicate_entity_issue(
+    hass: HomeAssistant,
+    entry: StiebelEltronConfigEntry,
+    model: ControllerModel,
+    losers: list[er.RegistryEntry],
+) -> None:
+    """Keep the config entry's duplicate-entity Repair in sync."""
+    issue_id = duplicate_entity_issue_id(entry)
+    if not losers:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+        return
+
+    entity_ids = sorted(registry_entry.entity_id for registry_entry in losers)
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        data={"entry_id": entry.entry_id, "model_id": model.value},
+        is_fixable=True,
+        is_persistent=True,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="duplicate_entities",
+        translation_placeholders={
+            "count": str(len(entity_ids)),
+            "entities": ", ".join(entity_ids),
+        },
+    )
+
+
+@callback
 def async_migrate_device_identifier(
     hass: HomeAssistant, entry: StiebelEltronConfigEntry
 ) -> None:
@@ -263,10 +319,11 @@ async def async_migrate_unique_ids(
         _legacy_prefixes(entry, model),
         build_unique_id(entry, ""),
     )
+    async_sync_duplicate_entity_issue(hass, entry, model, losers)
 
     if not planned:
-        # Nothing left to migrate. A duplicate that was reported by an earlier
-        # run is still there, but it has been reported already.
+        # Nothing left to migrate. Any duplicate left by an earlier run is
+        # still reported through the persistent Repair synchronized above.
         return
 
     @callback
@@ -283,8 +340,9 @@ async def async_migrate_unique_ids(
         _LOGGER.warning(
             "%s entities were created twice, once before and once after the "
             "unique id change, so the following duplicates keep their old unique "
-            "id and stay unavailable: %s. Their recorded history can only be "
-            "merged manually, in Developer Tools under Statistics",
+            "id and stay unavailable: %s. Their recorded long-term statistics "
+            "remain separate after registry removal and can be removed deliberately "
+            "in Developer Tools under Statistics",
             len(losers),
             ", ".join(sorted(registry_entry.entity_id for registry_entry in losers)),
         )

--- a/custom_components/stiebel_eltron_isg/repairs.py
+++ b/custom_components/stiebel_eltron_isg/repairs.py
@@ -33,7 +33,9 @@ class DuplicateEntityRepairFlow(RepairsFlow):
         user_input: dict[str, Any] | None = None,
     ) -> RepairsFlowResult:
         """Start the Repair flow."""
-        return await self.async_step_confirm(user_input)
+        # The Repairs flow manager passes its own init data as user_input. It is
+        # context, not a user's confirmation of the destructive step.
+        return await self.async_step_confirm()
 
     async def async_step_confirm(
         self,
@@ -79,6 +81,8 @@ async def async_create_fix_flow(
 
     entry_id = data.get("entry_id")
     model_id = data.get("model_id")
+    # Use an exact int check so bool, which is an int subclass, cannot select a
+    # controller model accidentally.
     if not isinstance(entry_id, str) or type(model_id) is not int:
         return ConfirmRepairFlow()
 

--- a/custom_components/stiebel_eltron_isg/repairs.py
+++ b/custom_components/stiebel_eltron_isg/repairs.py
@@ -1,0 +1,94 @@
+"""Home Assistant Repairs for the Stiebel Eltron ISG integration."""
+
+from typing import Any
+
+from homeassistant.components.repairs import (
+    ConfirmRepairFlow,
+    RepairsFlow,
+    RepairsFlowResult,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from pystiebeleltron import ControllerModel
+
+from .const import DOMAIN
+from .coordinator import StiebelEltronConfigEntry
+from .migration import async_get_duplicate_entities, duplicate_entity_issue_id
+
+
+class DuplicateEntityRepairFlow(RepairsFlow):
+    """Confirm removal of entity-registry entries left by the ID migration."""
+
+    def __init__(
+        self,
+        entry: StiebelEltronConfigEntry,
+        model: ControllerModel,
+    ) -> None:
+        """Initialize the flow with stable identifiers from the Repair."""
+        self._entry = entry
+        self._model = model
+
+    async def async_step_init(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> RepairsFlowResult:
+        """Start the Repair flow."""
+        return await self.async_step_confirm(user_input)
+
+    async def async_step_confirm(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> RepairsFlowResult:
+        """Show and apply the explicitly confirmed registry cleanup."""
+        duplicates = async_get_duplicate_entities(
+            self.hass,
+            self._entry,
+            self._model,
+        )
+        issue_id = duplicate_entity_issue_id(self._entry)
+
+        if user_input is not None:
+            registry = er.async_get(self.hass)
+            for duplicate in duplicates:
+                registry.async_remove(duplicate.entity_id)
+            ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+            return self.async_create_entry(data={})
+
+        if not duplicates:
+            ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+            return self.async_abort(reason="no_duplicates")
+
+        entity_ids = sorted(duplicate.entity_id for duplicate in duplicates)
+        return self.async_show_form(
+            step_id="confirm",
+            description_placeholders={
+                "count": str(len(entity_ids)),
+                "entities": "\n".join(f"- `{entity_id}`" for entity_id in entity_ids),
+            },
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create a flow only for a valid duplicate-entity Repair."""
+    if data is None:
+        return ConfirmRepairFlow()
+
+    entry_id = data.get("entry_id")
+    model_id = data.get("model_id")
+    if not isinstance(entry_id, str) or type(model_id) is not int:
+        return ConfirmRepairFlow()
+
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if entry is None or issue_id != duplicate_entity_issue_id(entry):
+        return ConfirmRepairFlow()
+
+    try:
+        model = ControllerModel(model_id)
+    except ValueError:
+        return ConfirmRepairFlow()
+
+    return DuplicateEntityRepairFlow(entry, model)

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -51,7 +51,6 @@
     "issues": {
         "duplicate_entities": {
             "title": "Unavailable duplicate entities",
-            "description": "{count} duplicate entities from the 2026.7 unique-ID transition are no longer provided: {entities}. The integration kept the older working entities because dashboards, automations, history, and long-term statistics normally refer to them.",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -49,6 +49,21 @@
         }
     },
     "issues": {
+        "duplicate_entities": {
+            "title": "Unavailable duplicate entities",
+            "description": "{count} duplicate entities from the 2026.7 unique-ID transition are no longer provided: {entities}. The integration kept the older working entities because dashboards, automations, history, and long-term statistics normally refer to them.",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Remove unavailable duplicate entities",
+                        "description": "The following {count} entries will be removed from the entity registry: {entities}. Before continuing, make sure no dashboard or automation references these entity IDs. Separate long-term statistics are not merged or deleted automatically."
+                    }
+                },
+                "abort": {
+                    "no_duplicates": "The duplicate entities have already been removed."
+                }
+            }
+        },
         "unsupported_controller": {
             "title": "Unsupported controller model",
             "description": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and reload the entry. If it remains unavailable, support has not yet been released in both the device library and this integration; report the model ID in the project issue tracker."

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -56,7 +56,7 @@
                 "step": {
                     "confirm": {
                         "title": "Remove unavailable duplicate entities",
-                        "description": "The following {count} entries will be removed from the entity registry: {entities}. Before continuing, make sure no dashboard or automation references these entity IDs. Separate long-term statistics are not merged or deleted automatically."
+                        "description": "The following {count} entries will be removed from the entity registry:\n\n{entities}\n\nBefore continuing, make sure no dashboard or automation references these entity IDs. Separate long-term statistics are not merged or deleted automatically."
                     }
                 },
                 "abort": {

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -53,7 +53,7 @@
                 "step": {
                     "confirm": {
                         "title": "Nicht verfügbare Dubletten entfernen",
-                        "description": "Die folgenden {count} Einträge werden aus der Entitätsregistrierung entfernt: {entities}. Prüfen Sie vorher, dass kein Dashboard und keine Automatisierung diese Entitäts-IDs verwendet. Separate Langzeitstatistiken werden nicht zusammengeführt oder automatisch gelöscht."
+                        "description": "Die folgenden {count} Einträge werden aus der Entitätsregistrierung entfernt:\n\n{entities}\n\nPrüfen Sie vorher, dass kein Dashboard und keine Automatisierung diese Entitäts-IDs verwendet. Separate Langzeitstatistiken werden weder zusammengeführt noch automatisch gelöscht."
                     }
                 },
                 "abort": {

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -46,6 +46,21 @@
         }
     },
     "issues": {
+        "duplicate_entities": {
+            "title": "Nicht verfügbare doppelte Entitäten",
+            "description": "{count} doppelte Entitäten aus der Unique-ID-Umstellung in Version 2026.7 werden nicht mehr bereitgestellt: {entities}. Die Integration hat die älteren funktionierenden Entitäten beibehalten, weil Dashboards, Automatisierungen, Verlauf und Langzeitstatistiken normalerweise auf sie verweisen.",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Nicht verfügbare Dubletten entfernen",
+                        "description": "Die folgenden {count} Einträge werden aus der Entitätsregistrierung entfernt: {entities}. Prüfen Sie vorher, dass kein Dashboard und keine Automatisierung diese Entitäts-IDs verwendet. Separate Langzeitstatistiken werden nicht zusammengeführt oder automatisch gelöscht."
+                    }
+                },
+                "abort": {
+                    "no_duplicates": "Die doppelten Entitäten wurden bereits entfernt."
+                }
+            }
+        },
         "unsupported_controller": {
             "title": "Nicht unterstütztes Reglermodell",
             "description": "Das ISG meldet die Reglermodell-ID {model_id}, die von dieser Version der Integration nicht unterstützt wird. Aktualisieren Sie die Integration und laden Sie den Eintrag erneut. Falls er weiterhin nicht verfügbar ist, wurde die Unterstützung noch nicht in der Gerätebibliothek und dieser Integration veröffentlicht; melden Sie die Modell-ID im Issue-Tracker des Projekts."

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -48,7 +48,6 @@
     "issues": {
         "duplicate_entities": {
             "title": "Nicht verfügbare doppelte Entitäten",
-            "description": "{count} doppelte Entitäten aus der Unique-ID-Umstellung in Version 2026.7 werden nicht mehr bereitgestellt: {entities}. Die Integration hat die älteren funktionierenden Entitäten beibehalten, weil Dashboards, Automatisierungen, Verlauf und Langzeitstatistiken normalerweise auf sie verweisen.",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -51,7 +51,6 @@
     "issues": {
         "duplicate_entities": {
             "title": "Unavailable duplicate entities",
-            "description": "{count} duplicate entities from the 2026.7 unique-ID transition are no longer provided: {entities}. The integration kept the older working entities because dashboards, automations, history, and long-term statistics normally refer to them.",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -49,6 +49,21 @@
         }
     },
     "issues": {
+        "duplicate_entities": {
+            "title": "Unavailable duplicate entities",
+            "description": "{count} duplicate entities from the 2026.7 unique-ID transition are no longer provided: {entities}. The integration kept the older working entities because dashboards, automations, history, and long-term statistics normally refer to them.",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Remove unavailable duplicate entities",
+                        "description": "The following {count} entries will be removed from the entity registry: {entities}. Before continuing, make sure no dashboard or automation references these entity IDs. Separate long-term statistics are not merged or deleted automatically."
+                    }
+                },
+                "abort": {
+                    "no_duplicates": "The duplicate entities have already been removed."
+                }
+            }
+        },
         "unsupported_controller": {
             "title": "Unsupported controller model",
             "description": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and reload the entry. If it remains unavailable, support has not yet been released in both the device library and this integration; report the model ID in the project issue tracker."

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -56,7 +56,7 @@
                 "step": {
                     "confirm": {
                         "title": "Remove unavailable duplicate entities",
-                        "description": "The following {count} entries will be removed from the entity registry: {entities}. Before continuing, make sure no dashboard or automation references these entity IDs. Separate long-term statistics are not merged or deleted automatically."
+                        "description": "The following {count} entries will be removed from the entity registry:\n\n{entities}\n\nBefore continuing, make sure no dashboard or automation references these entity IDs. Separate long-term statistics are not merged or deleted automatically."
                     }
                 },
                 "abort": {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -19,6 +19,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.stiebel_eltron_isg.const import CURRENT_POWER_CONSUMPTION, DOMAIN
 from custom_components.stiebel_eltron_isg.entity import build_unique_id
+from custom_components.stiebel_eltron_isg.migration import duplicate_entity_issue_id
 from custom_components.stiebel_eltron_isg.sensor import WPM_SENSOR_TYPES
 from custom_components.stiebel_eltron_isg.wpm3i_coordinator import (
     StiebelEltronModbusWPM3iDataCoordinator,
@@ -297,21 +298,38 @@ async def test_async_setup_entry_rejects_unhandled_model(
     assert mock_modbus_connection.connected is False
 
 
-async def test_removing_entry_clears_controller_repair(
+async def test_removing_entry_clears_its_repairs(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_get_controller_model: MagicMock,
 ) -> None:
-    """Deleting a failed entry must not leave an orphaned repair."""
-    issue_id = f"unsupported_controller_{mock_config_entry.entry_id}"
+    """Deleting an entry must not leave either Repair orphaned."""
+    controller_issue_id = f"unsupported_controller_{mock_config_entry.entry_id}"
+    duplicate_issue_id = duplicate_entity_issue_id(mock_config_entry)
     mock_get_controller_model.side_effect = UnknownControllerModelError(165)
     mock_config_entry.add_to_hass(hass)
     assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is not None
+    assert ir.async_get(hass).async_get_issue(DOMAIN, controller_issue_id) is not None
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        duplicate_issue_id,
+        data={
+            "entry_id": mock_config_entry.entry_id,
+            "model_id": ControllerModel.WPM_3.value,
+        },
+        is_fixable=True,
+        is_persistent=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="duplicate_entities",
+        translation_placeholders={"count": "1", "entities": "sensor.duplicate"},
+    )
 
     await hass.config_entries.async_remove(mock_config_entry.entry_id)
 
-    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None
+    issue_registry = ir.async_get(hass)
+    assert issue_registry.async_get_issue(DOMAIN, controller_issue_id) is None
+    assert issue_registry.async_get_issue(DOMAIN, duplicate_issue_id) is None
 
 
 async def test_async_setup_entry_coordinator_update_fails(

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -3,7 +3,11 @@
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from pystiebeleltron import ControllerModel
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -247,6 +251,24 @@ async def test_configured_name_wins_over_the_replacement_entity(
         == f"{DOMAIN}_{MODEL_NAME}_{KEY}"
     )
     assert replacement.entity_id in caplog.text
+    assert "remain separate" in caplog.text
+    assert "merged manually" not in caplog.text
+
+    issue = ir.async_get(hass).async_get_issue(
+        DOMAIN, f"duplicate_entities_{config_entry_with_name.entry_id}"
+    )
+    assert issue is not None
+    assert issue.is_fixable is True
+    assert issue.is_persistent is True
+    assert issue.severity is ir.IssueSeverity.WARNING
+    assert issue.data == {
+        "entry_id": config_entry_with_name.entry_id,
+        "model_id": ControllerModel.WPM_3.value,
+    }
+    assert issue.translation_placeholders == {
+        "count": "1",
+        "entities": replacement.entity_id,
+    }
 
 
 async def test_reload_with_a_leftover_duplicate_does_not_fail(
@@ -289,6 +311,40 @@ async def test_reload_with_a_leftover_duplicate_does_not_fail(
         registry.async_get(replacement.entity_id).unique_id
         == f"{DOMAIN}_{MODEL_NAME}_{KEY}"
     )
+    assert (
+        ir.async_get(hass).async_get_issue(
+            DOMAIN, f"duplicate_entities_{config_entry_with_name.entry_id}"
+        )
+        is not None
+    )
+
+
+async def test_setup_clears_a_stale_duplicate_entity_repair(
+    hass: HomeAssistant,
+    config_entry_with_name: MockConfigEntry,
+) -> None:
+    """A Repair must disappear after every duplicate has been removed."""
+    issue_id = f"duplicate_entities_{config_entry_with_name.entry_id}"
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        data={
+            "entry_id": config_entry_with_name.entry_id,
+            "model_id": ControllerModel.WPM_3.value,
+        },
+        is_fixable=True,
+        is_persistent=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="duplicate_entities",
+        translation_placeholders={"count": "1", "entities": "sensor.duplicate"},
+    )
+    config_entry_with_name.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry_with_name.entry_id)
+    await hass.async_block_till_done()
+
+    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None
 
 
 async def test_migrates_the_title_of_an_entry_without_a_configured_name(

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -7,6 +7,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.setup import async_setup_component
 from pystiebeleltron import ControllerModel
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -117,6 +118,33 @@ async def test_confirmed_repair_removes_only_current_duplicate_losers(
         )
         is None
     )
+
+
+async def test_opening_repair_through_flow_manager_never_confirms_removal(
+    hass: HomeAssistant,
+    legacy_config_entry: MockConfigEntry,
+) -> None:
+    """The manager's init data must not be mistaken for user confirmation."""
+    winner, loser = _register_duplicate_pair(hass, legacy_config_entry)
+    _create_duplicate_issue(hass, legacy_config_entry)
+    assert await async_setup_component(hass, DOMAIN, {})
+    assert await async_setup_component(hass, "repairs", {})
+
+    flow_manager = hass.data["repairs"]["flow_manager"]
+    result = await flow_manager.async_init(
+        DOMAIN,
+        data={"issue_id": duplicate_entity_issue_id(legacy_config_entry)},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    assert result["description_placeholders"] == {
+        "count": "1",
+        "entities": f"- `{loser.entity_id}`",
+    }
+    registry = er.async_get(hass)
+    assert registry.async_get(winner.entity_id) is not None
+    assert registry.async_get(loser.entity_id) is not None
 
 
 async def test_repair_revalidates_losers_before_removing_anything(

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,0 +1,195 @@
+"""Tests for Home Assistant Repairs exposed by the integration."""
+
+from typing import Any
+
+from homeassistant.components.repairs import ConfirmRepairFlow
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from pystiebeleltron import ControllerModel
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.stiebel_eltron_isg import repairs
+from custom_components.stiebel_eltron_isg.const import DOMAIN
+from custom_components.stiebel_eltron_isg.migration import duplicate_entity_issue_id
+
+MODEL = ControllerModel.WPM_3
+MODEL_NAME = "Stiebel Eltron WPM_3"
+KEY = "outdoor_temperature"
+
+
+@pytest.fixture
+def legacy_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Register an entry that was created before the 2026.7 transition."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Stiebel Eltron",
+        data={CONF_HOST: "1.1.1.1", CONF_PORT: 502, CONF_NAME: "My Heatpump"},
+        entry_id="stiebel_eltron_repair",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _register_duplicate_pair(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+) -> tuple[er.RegistryEntry, er.RegistryEntry]:
+    """Register an already-migrated winner and its model-name duplicate."""
+    registry = er.async_get(hass)
+    winner = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{entry.entry_id}_{KEY}",
+        config_entry=entry,
+        suggested_object_id="stiebel_eltron_isg_outdoor_temperature",
+    )
+    loser = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_{MODEL_NAME}_{KEY}",
+        config_entry=entry,
+        suggested_object_id="stiebel_eltron_wpm_3_aussentemperatur",
+    )
+    return winner, loser
+
+
+def _create_duplicate_issue(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Create the Repair that launches the cleanup flow."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        duplicate_entity_issue_id(entry),
+        data={"entry_id": entry.entry_id, "model_id": MODEL.value},
+        is_fixable=True,
+        is_persistent=True,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="duplicate_entities",
+        translation_placeholders={"count": "1", "entities": "sensor.duplicate"},
+    )
+
+
+async def _create_flow(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+) -> repairs.DuplicateEntityRepairFlow:
+    """Create a live duplicate cleanup flow through its public factory."""
+    flow = await repairs.async_create_fix_flow(
+        hass,
+        duplicate_entity_issue_id(entry),
+        {"entry_id": entry.entry_id, "model_id": MODEL.value},
+    )
+    assert isinstance(flow, repairs.DuplicateEntityRepairFlow)
+    flow.hass = hass
+    return flow
+
+
+async def test_confirmed_repair_removes_only_current_duplicate_losers(
+    hass: HomeAssistant,
+    legacy_config_entry: MockConfigEntry,
+) -> None:
+    """Confirmation removes the orphan while preserving the working winner."""
+    winner, loser = _register_duplicate_pair(hass, legacy_config_entry)
+    _create_duplicate_issue(hass, legacy_config_entry)
+    flow = await _create_flow(hass, legacy_config_entry)
+
+    form = await flow.async_step_init()
+
+    assert form["type"] is FlowResultType.FORM
+    assert form["step_id"] == "confirm"
+    assert form["description_placeholders"] == {
+        "count": "1",
+        "entities": f"- `{loser.entity_id}`",
+    }
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    registry = er.async_get(hass)
+    assert registry.async_get(winner.entity_id) is not None
+    assert registry.async_get(loser.entity_id) is None
+    assert (
+        ir.async_get(hass).async_get_issue(
+            DOMAIN, duplicate_entity_issue_id(legacy_config_entry)
+        )
+        is None
+    )
+
+
+async def test_repair_revalidates_losers_before_removing_anything(
+    hass: HomeAssistant,
+    legacy_config_entry: MockConfigEntry,
+) -> None:
+    """A former loser survives if its winner disappears before confirmation."""
+    winner, former_loser = _register_duplicate_pair(hass, legacy_config_entry)
+    _create_duplicate_issue(hass, legacy_config_entry)
+    flow = await _create_flow(hass, legacy_config_entry)
+    assert (await flow.async_step_init())["type"] is FlowResultType.FORM
+
+    er.async_get(hass).async_remove(winner.entity_id)
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert er.async_get(hass).async_get(former_loser.entity_id) is not None
+
+
+async def test_repair_aborts_after_duplicates_were_removed_manually(
+    hass: HomeAssistant,
+    legacy_config_entry: MockConfigEntry,
+) -> None:
+    """Opening a stale Repair performs no registry mutation."""
+    _create_duplicate_issue(hass, legacy_config_entry)
+    flow = await _create_flow(hass, legacy_config_entry)
+
+    result = await flow.async_step_init()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_duplicates"
+    assert (
+        ir.async_get(hass).async_get_issue(
+            DOMAIN, duplicate_entity_issue_id(legacy_config_entry)
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("issue_id", "data"),
+    [
+        ("duplicate_entities_missing", None),
+        (
+            "duplicate_entities_missing",
+            {"entry_id": "missing", "model_id": MODEL.value},
+        ),
+        (
+            "duplicate_entities_stiebel_eltron_repair",
+            {"entry_id": "stiebel_eltron_repair", "model_id": "invalid"},
+        ),
+        (
+            "duplicate_entities_stiebel_eltron_repair",
+            {"entry_id": "stiebel_eltron_repair", "model_id": 999},
+        ),
+        (
+            "unrelated_stiebel_eltron_repair",
+            {"entry_id": "stiebel_eltron_repair", "model_id": MODEL.value},
+        ),
+    ],
+)
+async def test_malformed_repair_data_never_removes_registry_entries(
+    hass: HomeAssistant,
+    legacy_config_entry: MockConfigEntry,
+    issue_id: str,
+    data: dict[str, Any] | None,
+) -> None:
+    """Untrusted Repair identifiers cannot reach the deletion flow."""
+    winner, loser = _register_duplicate_pair(hass, legacy_config_entry)
+
+    flow = await repairs.async_create_fix_flow(hass, issue_id, data)
+
+    assert isinstance(flow, ConfirmRepairFlow)
+    registry = er.async_get(hass)
+    assert registry.async_get(winner.entity_id) is not None
+    assert registry.async_get(loser.entity_id) is not None

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -388,6 +388,32 @@ def test_controller_repair_uses_model_id_placeholder(
     assert placeholders == {"model_id"}
 
 
+@pytest.mark.parametrize(
+    "translation_file",
+    _repair_translation_files(),
+    ids=lambda file: file.name,
+)
+def test_duplicate_entity_repair_preserves_safety_placeholders(
+    translation_file: pathlib.Path,
+) -> None:
+    """Runtime copy must identify the exact entries at both decision points."""
+    issue = json.loads(translation_file.read_text(encoding="utf-8"))["issues"][
+        "duplicate_entities"
+    ]
+
+    def placeholders(text: str) -> set[str]:
+        return {
+            field for _, field, _, _ in Formatter().parse(text) if field is not None
+        }
+
+    assert placeholders(issue["description"]) == {"count", "entities"}
+    assert placeholders(issue["fix_flow"]["step"]["confirm"]["description"]) == {
+        "count",
+        "entities",
+    }
+    assert placeholders(issue["fix_flow"]["abort"]["no_duplicates"]) == set()
+
+
 def test_config_flow_strings_match_runtime_fields() -> None:
     """Config-flow strings must describe the fields and forms users can open."""
     steps = json.loads(_STRINGS_FILE.read_text(encoding="utf-8"))["config"]["step"]

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -396,7 +396,7 @@ def test_controller_repair_uses_model_id_placeholder(
 def test_duplicate_entity_repair_preserves_safety_placeholders(
     translation_file: pathlib.Path,
 ) -> None:
-    """Runtime copy must identify the exact entries at both decision points."""
+    """A fixable Repair must identify exact entries without a competing description."""
     issue = json.loads(translation_file.read_text(encoding="utf-8"))["issues"][
         "duplicate_entities"
     ]
@@ -406,7 +406,7 @@ def test_duplicate_entity_repair_preserves_safety_placeholders(
             field for _, field, _, _ in Formatter().parse(text) if field is not None
         }
 
-    assert placeholders(issue["description"]) == {"count", "entities"}
+    assert "description" not in issue
     assert placeholders(issue["fix_flow"]["step"]["confirm"]["description"]) == {
         "count",
         "entities",


### PR DESCRIPTION
The 2026.7 unique-ID migration keeps the older working registry entry when an entity exists twice, because dashboards, automations, history, and long-term statistics point at it. The model-named duplicate keeps its legacy unique ID and stays unavailable; until now it only surfaced as a log warning most users never see (#649).

This PR turns that leftover into a persistent, fixable Repair per config entry:

- The Repair lists the exact duplicate entity IDs and is created, updated, or deleted on every migration run.
- The fix flow shows the IDs again, tells the user to check dashboard and automation references first, and states that long-term statistics are neither merged nor deleted; removing those stays a manual step in Developer Tools.
- The duplicate list is recomputed immediately before removal, so a stale Repair cannot delete entries that no longer collide.
- Removal happens only after explicit confirmation; automatic cleanup is deliberately out because deleting registry entries is destructive.

RepairsFlowManager passes its init data as `user_input` to `async_step_init`. A regression test on that real path proves that opening the Repair never counts as confirmation; the confirm form is always shown.

Verified with `ruff format --check`, `ruff check`, `mypy`, and the test suite (896 passed, 1 skipped).

## Summary by Sourcery

Introduce a fixable, persistent Repair for duplicate entities left by the unique-ID migration and ensure related issues are safely created, synchronized, and cleaned up.

New Features:
- Add a Repairs-based flow to list and optionally remove duplicate entity registry entries per config entry.
- Expose a dedicated duplicate-entity Repair issue type tied to each config entry and controller model.

Bug Fixes:
- Ensure removing a config entry clears both controller and duplicate-entity Repair issues and that malformed Repair data cannot trigger entity deletion.
- Prevent stale Repairs from deleting entities that are no longer in a duplicate state by revalidating losers before removal.

Enhancements:
- Replace the previous transient log-only duplicate warning with clearer guidance and safer wording about long-term statistics handling.
- Document the preferred cleanup path for unavailable duplicate entities and clarify how statistics are preserved and not auto-merged.
- Refine translation strings and tests so duplicate-entity Repairs use safe placeholders and consistent messaging across languages.

Tests:
- Add extensive tests for the new duplicate-entity Repair flow, including confirmation behavior, stale and malformed cases, and interaction with the Repairs flow manager.
- Extend migration, init, and translation tests to cover duplicate-entity Repairs, updated logging text, and issue lifecycle behavior.