### PR TITLE
Report unsupported controller IDs in the config flow

### DIFF
--- a/custom_components/stiebel_eltron_isg/config_flow.py
+++ b/custom_components/stiebel_eltron_isg/config_flow.py
@@ -64,7 +64,10 @@ async def check_controller_model(host: str, port: int) -> ControllerCheckResult:
             "unsupported_controller",
             MappingProxyType({"model_id": str(exception.model_id)}),
         )
-    except StiebelEltronModbusError, ModbusError:
+    except StiebelEltronModbusError:
+        _LOGGER.debug("Cannot connect to Stiebel Eltron device", exc_info=True)
+        return ControllerCheckResult("cannot_connect")
+    except ModbusError:
         _LOGGER.debug("Cannot connect to Stiebel Eltron device", exc_info=True)
         return ControllerCheckResult("cannot_connect")
     except Exception:

--- a/custom_components/stiebel_eltron_isg/config_flow.py
+++ b/custom_components/stiebel_eltron_isg/config_flow.py
@@ -1,9 +1,7 @@
 """Config flow for the STIEBEL ELTRON integration."""
 
-from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 import logging
-from types import MappingProxyType
 from typing import Any, override
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -45,9 +43,7 @@ class ControllerCheckResult:
     """Result of validating a controller during a config flow."""
 
     error: str | None = None
-    description_placeholders: Mapping[str, str] = field(
-        default_factory=lambda: MappingProxyType({})
-    )
+    description_placeholders: dict[str, str] | None = None
 
 
 async def check_controller_model(host: str, port: int) -> ControllerCheckResult:
@@ -62,7 +58,7 @@ async def check_controller_model(host: str, port: int) -> ControllerCheckResult:
         _LOGGER.debug("Unsupported controller model %s", exception.model_id)
         return ControllerCheckResult(
             "unsupported_controller",
-            MappingProxyType({"model_id": str(exception.model_id)}),
+            {"model_id": str(exception.model_id)},
         )
     except StiebelEltronModbusError:
         _LOGGER.debug("Cannot connect to Stiebel Eltron device", exc_info=True)
@@ -96,7 +92,7 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
         if check_result.error is not None:
             return self.async_abort(
                 reason=check_result.error,
-                description_placeholders=dict(check_result.description_placeholders),
+                description_placeholders=check_result.description_placeholders,
             )
 
         self._discovered_host = discovery_info.ip
@@ -125,7 +121,7 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
-        description_placeholders: dict[str, str] = {}
+        description_placeholders: dict[str, str] | None = None
         if user_input is not None:
             self._async_abort_entries_match({
                 CONF_HOST: user_input[CONF_HOST],
@@ -136,7 +132,7 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             if check_result.error is not None:
                 errors["base"] = check_result.error
-                description_placeholders = dict(check_result.description_placeholders)
+                description_placeholders = check_result.description_placeholders
             else:
                 return self.async_create_entry(title="Stiebel Eltron", data=user_input)
 
@@ -154,7 +150,7 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
         config_entry = self._get_reconfigure_entry()
 
         errors: dict[str, str] = {}
-        description_placeholders: dict[str, str] = {}
+        description_placeholders: dict[str, str] | None = None
         if user_input is not None:
             self._async_abort_entries_match({
                 CONF_HOST: user_input[CONF_HOST],
@@ -165,7 +161,7 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             if check_result.error is not None:
                 errors["base"] = check_result.error
-                description_placeholders = dict(check_result.description_placeholders)
+                description_placeholders = check_result.description_placeholders
             else:
                 return self.async_update_reload_and_abort(
                     config_entry,

--- a/custom_components/stiebel_eltron_isg/config_flow.py
+++ b/custom_components/stiebel_eltron_isg/config_flow.py
@@ -1,6 +1,9 @@
 """Config flow for the STIEBEL ELTRON integration."""
 
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 import logging
+from types import MappingProxyType
 from typing import Any, override
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -15,7 +18,11 @@ from homeassistant.helpers.selector import (
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from modbus_connection import ModbusError
 from modbus_connection.pymodbus import connect_tcp
-from pystiebeleltron import StiebelEltronModbusError, get_controller_model
+from pystiebeleltron import (
+    StiebelEltronModbusError,
+    UnknownControllerModelError,
+    get_controller_model,
+)
 import voluptuous as vol
 
 from .const import DEFAULT_PORT, DOMAIN, UNIT_ID
@@ -33,7 +40,17 @@ STEP_USER_DATA_SCHEMA = vol.Schema({
 })
 
 
-async def check_controller_model(host: str, port: int) -> str | None:
+@dataclass(frozen=True)
+class ControllerCheckResult:
+    """Result of validating a controller during a config flow."""
+
+    error: str | None = None
+    description_placeholders: Mapping[str, str] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+
+
+async def check_controller_model(host: str, port: int) -> ControllerCheckResult:
     """Check if the controller model is valid."""
     try:
         connection = await connect_tcp(host, port=port)
@@ -41,16 +58,19 @@ async def check_controller_model(host: str, port: int) -> str | None:
             await get_controller_model(connection.for_unit(UNIT_ID))
         finally:
             await connection.close()
-    except StiebelEltronModbusError:
+    except UnknownControllerModelError as exception:
+        _LOGGER.debug("Unsupported controller model %s", exception.model_id)
+        return ControllerCheckResult(
+            "unsupported_controller",
+            MappingProxyType({"model_id": str(exception.model_id)}),
+        )
+    except StiebelEltronModbusError, ModbusError:
         _LOGGER.debug("Cannot connect to Stiebel Eltron device", exc_info=True)
-        return "cannot_connect"
-    except ModbusError:
-        _LOGGER.debug("Cannot connect to Stiebel Eltron device", exc_info=True)
-        return "cannot_connect"
+        return ControllerCheckResult("cannot_connect")
     except Exception:
         _LOGGER.exception("Unexpected exception")
-        return "unknown"
-    return None
+        return ControllerCheckResult("unknown")
+    return ControllerCheckResult()
 
 
 class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -69,9 +89,12 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
         self._async_abort_entries_match({CONF_HOST: discovery_info.ip})
 
-        error = await check_controller_model(discovery_info.ip, DEFAULT_PORT)
-        if error is not None:
-            return self.async_abort(reason=error)
+        check_result = await check_controller_model(discovery_info.ip, DEFAULT_PORT)
+        if check_result.error is not None:
+            return self.async_abort(
+                reason=check_result.error,
+                description_placeholders=dict(check_result.description_placeholders),
+            )
 
         self._discovered_host = discovery_info.ip
         self.context["title_placeholders"] = {CONF_HOST: discovery_info.ip}
@@ -99,16 +122,18 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
+        description_placeholders: dict[str, str] = {}
         if user_input is not None:
             self._async_abort_entries_match({
                 CONF_HOST: user_input[CONF_HOST],
                 CONF_PORT: user_input[CONF_PORT],
             })
-            error = await check_controller_model(
+            check_result = await check_controller_model(
                 user_input[CONF_HOST], user_input[CONF_PORT]
             )
-            if error is not None:
-                errors["base"] = error
+            if check_result.error is not None:
+                errors["base"] = check_result.error
+                description_placeholders = dict(check_result.description_placeholders)
             else:
                 return self.async_create_entry(title="Stiebel Eltron", data=user_input)
 
@@ -116,6 +141,7 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
+            description_placeholders=description_placeholders,
         )
 
     async def async_step_reconfigure(
@@ -125,16 +151,18 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
         config_entry = self._get_reconfigure_entry()
 
         errors: dict[str, str] = {}
+        description_placeholders: dict[str, str] = {}
         if user_input is not None:
             self._async_abort_entries_match({
                 CONF_HOST: user_input[CONF_HOST],
                 CONF_PORT: user_input[CONF_PORT],
             })
-            error = await check_controller_model(
+            check_result = await check_controller_model(
                 user_input[CONF_HOST], user_input[CONF_PORT]
             )
-            if error is not None:
-                errors["base"] = error
+            if check_result.error is not None:
+                errors["base"] = check_result.error
+                description_placeholders = dict(check_result.description_placeholders)
             else:
                 return self.async_update_reload_and_abort(
                     config_entry,
@@ -150,4 +178,5 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
                 STEP_USER_DATA_SCHEMA, config_entry.data
             ),
             errors=errors,
+            description_placeholders=description_placeholders,
         )

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -31,12 +31,12 @@
             "already_configured": "Device is already configured",
             "invalid_host_IP": "Invalid host IP",
             "cannot_connect": "Cannot connect to the device. Please check the host and port.",
-            "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and try again."
+            "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Check for an integration update. If the model remains unsupported, report this model ID in the project issue tracker."
         },
         "abort": {
             "already_configured": "Device is already configured",
             "reconfigure_successful": "Connection details updated successfully.",
-            "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and try again."
+            "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Check for an integration update. If the model remains unsupported, report this model ID in the project issue tracker."
         }
     },
     "exceptions": {

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -30,11 +30,13 @@
         "error": {
             "already_configured": "Device is already configured",
             "invalid_host_IP": "Invalid host IP",
-            "cannot_connect": "Cannot connect to the device. Please check the host and port."
+            "cannot_connect": "Cannot connect to the device. Please check the host and port.",
+            "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and try again."
         },
         "abort": {
             "already_configured": "Device is already configured",
-            "reconfigure_successful": "Connection details updated successfully."
+            "reconfigure_successful": "Connection details updated successfully.",
+            "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and try again."
         }
     },
     "exceptions": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -30,11 +30,13 @@
         "error": {
             "already_configured": "The device is already configured.",
             "invalid_host_IP": "Invalid host address",
-            "cannot_connect": "Cannot connect to the device. Please check the host and port."
+            "cannot_connect": "Cannot connect to the device. Please check the host and port.",
+            "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and try again."
         },
         "abort": {
             "already_configured": "The device is already configured.",
-            "reconfigure_successful": "Connection details updated successfully."
+            "reconfigure_successful": "Connection details updated successfully.",
+            "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and try again."
         }
     },
     "exceptions": {

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -31,12 +31,12 @@
             "already_configured": "The device is already configured.",
             "invalid_host_IP": "Invalid host address",
             "cannot_connect": "Cannot connect to the device. Please check the host and port.",
-            "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and try again."
+            "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Check for an integration update. If the model remains unsupported, report this model ID in the project issue tracker."
         },
         "abort": {
             "already_configured": "The device is already configured.",
             "reconfigure_successful": "Connection details updated successfully.",
-            "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Update the integration and try again."
+            "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Check for an integration update. If the model remains unsupported, report this model ID in the project issue tracker."
         }
     },
     "exceptions": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from modbus_connection import ModbusError
+from modbus_connection.mock import MockModbusConnection
 from pystiebeleltron import (
     ControllerModel,
     StiebelEltronModbusError,
@@ -119,6 +120,7 @@ async def test_form_unknown_exception(
 async def test_form_reports_unsupported_controller(
     hass: HomeAssistant,
     mock_get_controller_model: MagicMock,
+    mock_modbus_connection: MockModbusConnection,
 ) -> None:
     """Test the user form reports an unsupported controller and its model ID."""
     mock_get_controller_model.side_effect = UnknownControllerModelError(165)
@@ -134,6 +136,14 @@ async def test_form_reports_unsupported_controller(
     assert result["errors"] == {"base": "unsupported_controller"}
     assert result["description_placeholders"] == {"model_id": "165"}
     assert hass.config_entries.async_entries(DOMAIN) == []
+    assert mock_modbus_connection.connected is False
+
+    mock_get_controller_model.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_reconfigure_flow(
@@ -227,6 +237,19 @@ async def test_reconfigure_reports_unsupported_controller(
     assert result["errors"] == {"base": "unsupported_controller"}
     assert result["description_placeholders"] == {"model_id": "165"}
     assert dict(mock_config_entry.data) == original_data
+
+    mock_get_controller_model.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], RECONFIGURE_INPUT
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert dict(mock_config_entry.data) == RECONFIGURE_INPUT
+
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
 
 async def test_reconfigure_flow_already_configured(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,7 +8,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from modbus_connection import ModbusError
-from pystiebeleltron import ControllerModel, StiebelEltronModbusError
+from pystiebeleltron import (
+    ControllerModel,
+    StiebelEltronModbusError,
+    UnknownControllerModelError,
+)
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -112,6 +116,26 @@ async def test_form_unknown_exception(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
+async def test_form_reports_unsupported_controller(
+    hass: HomeAssistant,
+    mock_get_controller_model: MagicMock,
+) -> None:
+    """Test the user form reports an unsupported controller and its model ID."""
+    mock_get_controller_model.side_effect = UnknownControllerModelError(165)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unsupported_controller"}
+    assert result["description_placeholders"] == {"model_id": "165"}
+    assert hass.config_entries.async_entries(DOMAIN) == []
+
+
 async def test_reconfigure_flow(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -181,6 +205,30 @@ async def test_reconfigure_flow_errors(
     await hass.async_block_till_done()
 
 
+async def test_reconfigure_reports_unsupported_controller(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_get_controller_model: MagicMock,
+) -> None:
+    """Test reconfiguration preserves data for an unsupported controller."""
+    original_data = dict(mock_config_entry.data)
+    mock_config_entry.add_to_hass(hass)
+    mock_get_controller_model.side_effect = UnknownControllerModelError(165)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": mock_config_entry.entry_id},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], RECONFIGURE_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unsupported_controller"}
+    assert result["description_placeholders"] == {"model_id": "165"}
+    assert dict(mock_config_entry.data) == original_data
+
+
 async def test_reconfigure_flow_already_configured(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -242,6 +290,23 @@ async def test_dhcp_discovery_flow(hass: HomeAssistant) -> None:
     assert result["title"] == "Stiebel Eltron"
     assert result["data"] == {CONF_HOST: "1.1.1.2", CONF_PORT: 502}
     assert result["result"].unique_id == "00:00:00:00:00:01"
+
+
+async def test_dhcp_aborts_for_unsupported_controller(
+    hass: HomeAssistant,
+    mock_get_controller_model: MagicMock,
+) -> None:
+    """Test DHCP discovery reports an unsupported controller and its model ID."""
+    mock_get_controller_model.side_effect = UnknownControllerModelError(165)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=DHCP_DISCOVERY
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unsupported_controller"
+    assert result["description_placeholders"] == {"model_id": "165"}
+    assert hass.config_entries.async_entries(DOMAIN) == []
 
 
 async def test_dhcp_discovery_updates_host(hass: HomeAssistant) -> None:

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -351,6 +351,22 @@ def test_english_config_flow_matches_strings() -> None:
     assert _key_tree(english) == _key_tree(strings)
 
 
+@pytest.mark.parametrize("translation_file", [_STRINGS_FILE, _RUNTIME_FILE])
+@pytest.mark.parametrize("section", ["error", "abort"])
+def test_unsupported_controller_flow_uses_model_id_placeholder(
+    translation_file: pathlib.Path,
+    section: str,
+) -> None:
+    """Unsupported-controller flow text must include the reported model ID."""
+    config = _load_json(translation_file)["config"]
+    text = config[section]["unsupported_controller"]
+    placeholders = {
+        field for _, field, _, _ in Formatter().parse(text) if field is not None
+    }
+
+    assert placeholders == {"model_id"}
+
+
 @pytest.mark.parametrize(
     "translation_file",
     _runtime_repair_translation_files(),


### PR DESCRIPTION
Part of #629.

When `pystiebeleltron` raises `UnknownControllerModelError`, the config flow previously caught it in the generic `except Exception` branch and reported the standard `unknown` error, so users only saw a generic unexpected error and never which controller model ID was rejected. This patch adds an explicit handler that distinguishes unsupported controllers from unexpected failures and surfaces the model ID in the UI. Transient `StiebelEltronModbusError` and `ModbusError` still map to `cannot_connect`.

## Changes

- User setup and reconfigure show a translated `unsupported_controller` error that includes the model ID and remain retryable.
- DHCP discovery aborts with the same translated reason and model ID.
- Reconfigure leaves the existing entry data untouched on a failed attempt.
- The connection is closed on the exception path.
- The guidance tells the user to check for an integration update and to report the model ID if support is still missing. It does not promise that an update will add support.
- Existing `cannot_connect` and unexpected-error behavior is unchanged.

## Verification

- Tests cover the user flow, reconfigure, DHCP discovery, retryability, unchanged entry data, connection cleanup, and the placeholder contracts.
- 932 tests passed, 1 expected skip; `ruff check`, `ruff format --check`, and `mypy` are clean.
- No test against a live heat pump was performed.

## Scope

Based on current upstream `main` and independent of the open PRs. Only the handling of `UnknownControllerModelError` by the config flow changes.

## Summary by Sourcery

Improve config flow handling of unknown controller models by distinguishing unsupported controllers from connectivity and unexpected errors, and exposing the controller model ID in user-facing messages.

New Features:
- Surface a specific unsupported-controller error in the config flow that includes the rejected controller model ID for user, reconfigure, and DHCP discovery flows.

Enhancements:
- Refactor controller validation to return structured results including error codes and description placeholders for reuse across config flow steps.

Tests:
- Add config flow tests covering unsupported-controller handling, retry behavior, reconfigure data preservation, DHCP abort behavior, and translation placeholder contracts for the model ID in errors and aborts.