### PR TITLE
Preserve config flow input after errors and add missing error texts

### DIFF
--- a/custom_components/stiebel_eltron_isg/config_flow.py
+++ b/custom_components/stiebel_eltron_isg/config_flow.py
@@ -138,7 +138,9 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, user_input
+            ),
             errors=errors,
             description_placeholders=description_placeholders,
         )
@@ -174,7 +176,8 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
-                STEP_USER_DATA_SCHEMA, config_entry.data
+                STEP_USER_DATA_SCHEMA,
+                user_input if user_input is not None else config_entry.data,
             ),
             errors=errors,
             description_placeholders=description_placeholders,

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -31,11 +31,14 @@
             "already_configured": "Device is already configured",
             "invalid_host_IP": "Invalid host IP",
             "cannot_connect": "Cannot connect to the device. Please check the host and port.",
+            "unknown": "Unexpected error",
             "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Check for an integration update. If the model remains unsupported, report this model ID in the project issue tracker."
         },
         "abort": {
             "already_configured": "Device is already configured",
+            "cannot_connect": "Cannot connect to the device. Please check the host and port.",
             "reconfigure_successful": "Connection details updated successfully.",
+            "unknown": "Unexpected error",
             "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Check for an integration update. If the model remains unsupported, report this model ID in the project issue tracker."
         }
     },

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -31,11 +31,14 @@
             "already_configured": "The device is already configured.",
             "invalid_host_IP": "Invalid host address",
             "cannot_connect": "Cannot connect to the device. Please check the host and port.",
+            "unknown": "Unexpected error",
             "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Check for an integration update. If the model remains unsupported, report this model ID in the project issue tracker."
         },
         "abort": {
             "already_configured": "The device is already configured.",
+            "cannot_connect": "Cannot connect to the device. Please check the host and port.",
             "reconfigure_successful": "Connection details updated successfully.",
+            "unknown": "Unexpected error",
             "unsupported_controller": "The ISG reports controller model ID {model_id}, which this version of the integration does not support. Check for an integration update. If the model remains unsupported, report this model ID in the project issue tracker."
         }
     },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -28,6 +28,16 @@ DHCP_DISCOVERY = DhcpServiceInfo(
 )
 
 
+def assert_suggested_values(result, expected: dict[str, object]) -> None:
+    """Assert the values Home Assistant will suggest in a config-flow form."""
+    suggested_values = {
+        key.schema: key.description["suggested_value"]
+        for key in result["data_schema"].schema
+        if key.description is not None and "suggested_value" in key.description
+    }
+    assert suggested_values == expected
+
+
 async def test_full_flow(hass: HomeAssistant) -> None:
     """Test the full flow."""
     result = await hass.config_entries.flow.async_init(
@@ -76,6 +86,7 @@ async def test_form_cannot_connect(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
+    assert_suggested_values(result, USER_INPUT)
 
     failing_mock.side_effect = None
 
@@ -105,6 +116,7 @@ async def test_form_unknown_exception(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "unknown"}
+    assert_suggested_values(result, USER_INPUT)
 
     mock_get_controller_model.side_effect = None
     mock_get_controller_model.return_value = ControllerModel.LWZ  # Valid model (LWZ)
@@ -135,6 +147,7 @@ async def test_form_reports_unsupported_controller(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "unsupported_controller"}
     assert result["description_placeholders"] == {"model_id": "165"}
+    assert_suggested_values(result, USER_INPUT)
     assert hass.config_entries.async_entries(DOMAIN) == []
     assert mock_modbus_connection.connected is False
 
@@ -158,6 +171,7 @@ async def test_reconfigure_flow(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
+    assert_suggested_values(result, mock_config_entry.data)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -201,6 +215,7 @@ async def test_reconfigure_flow_errors(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": expected_error}
+    assert_suggested_values(result, RECONFIGURE_INPUT)
 
     mock_get_controller_model.side_effect = None
     result = await hass.config_entries.flow.async_configure(
@@ -236,6 +251,7 @@ async def test_reconfigure_reports_unsupported_controller(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "unsupported_controller"}
     assert result["description_placeholders"] == {"model_id": "165"}
+    assert_suggested_values(result, RECONFIGURE_INPUT)
     assert dict(mock_config_entry.data) == original_data
 
     mock_get_controller_model.side_effect = None

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -50,6 +50,11 @@ _STRINGS_FILE = _COMPONENT_DIR / "strings.json"
 _ICONS_FILE = _COMPONENT_DIR / "icons.json"
 _TRANSLATIONS_DIR = _COMPONENT_DIR / "translations"
 _RUNTIME_FILE = _TRANSLATIONS_DIR / "en.json"
+_CONTROLLER_VALIDATION_REASONS = {
+    "cannot_connect",
+    "unknown",
+    "unsupported_controller",
+}
 
 # This explicit snapshot keeps the small set of reviewed custom sensor icons
 # stable. The fan overrides preserve useful equipment context that the generic
@@ -170,6 +175,31 @@ def _key_tree(value):
 def test_translation_json_has_no_duplicate_keys(json_file: pathlib.Path) -> None:
     """Duplicate JSON keys must not be silently replaced by the parser."""
     _load_json(json_file)
+
+
+@pytest.mark.parametrize(
+    "json_file",
+    [_STRINGS_FILE, _RUNTIME_FILE],
+    ids=lambda file: file.name,
+)
+def test_controller_validation_reasons_have_flow_translations(
+    json_file: pathlib.Path,
+) -> None:
+    """Every validation result must render in forms and DHCP aborts."""
+    config = _load_json(json_file)["config"]
+    missing = {
+        section: sorted(
+            reason
+            for reason in _CONTROLLER_VALIDATION_REASONS
+            if not config[section].get(reason)
+        )
+        for section in ("error", "abort")
+        if any(
+            not config[section].get(reason) for reason in _CONTROLLER_VALIDATION_REASONS
+        )
+    }
+
+    assert not missing, f"{json_file.name} lacks config-flow translations: {missing}"
 
 
 @pytest.mark.parametrize("module", _PLATFORM_MODULES, ids=_platform)


### PR DESCRIPTION
After a controller validation failure, the manual setup schema returned by the user step has no suggested values for the submitted host and port.
The reconfigure step returns the stored entry values instead.
The initial reconfigure call should still show the stored values.
DHCP discovery can abort with `cannot_connect` or `unknown`, but `config.abort` had no texts for these reasons, and `config.error` had no text for `unknown`.

This patch keeps the submitted values as suggested values in the user and reconfigure steps after an error.
The initial reconfigure call still shows the stored entry values.
`strings.json` and `translations/en.json` get the missing literal texts.
Non-English translations are untouched.
Focused tests cover the schema suggested values and the translation contract.

Verification: 934 passed, 1 skipped.
Ruff check and format are clean.
mypy is clean.

## Summary by Sourcery

Preserve config flow field suggestions after validation errors and ensure controller validation reasons are fully translated in forms and DHCP aborts.

New Features:
- Retain user-entered host and port as suggested values in the manual setup and reconfigure forms after validation failures.
- Show stored config entry values as initial suggestions in the reconfigure form before any user changes.

Bug Fixes:
- Add missing config-flow error and abort texts for controller validation results such as `cannot_connect` and `unknown`.
- Guarantee that all controller validation reasons used by forms and DHCP discovery have corresponding translation strings.

Tests:
- Add config-flow tests asserting suggested values for user and reconfigure steps after errors and on initial reconfigure.
- Add translation contract tests verifying that all controller validation reasons have error and abort translations in strings and runtime JSON files.