### PR TITLE
Enable mypy strict mode for the integration

### DIFF
--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -21,7 +21,7 @@ from pystiebeleltron import (
 )
 
 from .const import DEFAULT_PORT, DOMAIN, UNIT_ID
-from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
+from .coordinator import AnyStiebelEltronDataCoordinator, StiebelEltronConfigEntry
 from .lwz_coordinator import StiebelEltronModbusLWZDataCoordinator
 from .migration import (
     async_migrate_device_identifier,
@@ -103,7 +103,7 @@ async def async_setup_entry(
             f"Unsupported controller model: {exception}"
         ) from exception
 
-    coordinator: StiebelEltronDataCoordinator
+    coordinator: AnyStiebelEltronDataCoordinator
 
     if model == ControllerModel.WPM_3i:
         coordinator = StiebelEltronModbusWPM3iDataCoordinator(

--- a/custom_components/stiebel_eltron_isg/binary_sensor.py
+++ b/custom_components/stiebel_eltron_isg/binary_sensor.py
@@ -72,7 +72,7 @@ from .const import (
     SWITCHING_PROGRAM_ENABLED,
     VENTILATION,
 )
-from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
+from .coordinator import AnyStiebelEltronDataCoordinator, StiebelEltronConfigEntry
 from .entity import StiebelEltronISGEntity
 
 PARALLEL_UPDATES = 1
@@ -534,7 +534,7 @@ class StiebelEltronISGBinarySensor(StiebelEltronISGEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        coordinator: StiebelEltronDataCoordinator,
+        coordinator: AnyStiebelEltronDataCoordinator,
         config_entry: StiebelEltronConfigEntry,
         description: StiebelEltronBinarySensorEntityDescription,
     ) -> None:

--- a/custom_components/stiebel_eltron_isg/button.py
+++ b/custom_components/stiebel_eltron_isg/button.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory
@@ -61,6 +61,8 @@ async def async_setup_entry(
 class StiebelEltronISGButtonEntity(StiebelEltronISGEntity, ButtonEntity):
     """stiebel_eltron_isg button class."""
 
+    entity_description: StiebelEltronISGButtonDescription
+
     def __init__(
         self,
         coordinator: AnyStiebelEltronDataCoordinator,
@@ -73,8 +75,7 @@ class StiebelEltronISGButtonEntity(StiebelEltronISGEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Trigger the button action."""
-        description = cast(StiebelEltronISGButtonDescription, self.entity_description)
-        await description.press_action(self.coordinator)
+        await self.entity_description.press_action(self.coordinator)
 
     @property
     def entity_registry_enabled_default(self) -> bool:

--- a/custom_components/stiebel_eltron_isg/button.py
+++ b/custom_components/stiebel_eltron_isg/button.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
+from typing import Any
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory
@@ -10,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import RESET_HEATPUMP
-from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
+from .coordinator import AnyStiebelEltronDataCoordinator, StiebelEltronConfigEntry
 from .entity import StiebelEltronISGEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +23,7 @@ PARALLEL_UPDATES = 1
 class StiebelEltronISGButtonDescriptionMixin:
     """Mixin to describe aStiebel Eltron ISG button."""
 
-    press_action: Callable[[StiebelEltronDataCoordinator], Coroutine]
+    press_action: Callable[[AnyStiebelEltronDataCoordinator], Coroutine[Any, Any, None]]
 
 
 @dataclass(frozen=True)
@@ -62,7 +63,7 @@ class StiebelEltronISGButtonEntity(StiebelEltronISGEntity, ButtonEntity):
 
     def __init__(
         self,
-        coordinator: StiebelEltronDataCoordinator,
+        coordinator: AnyStiebelEltronDataCoordinator,
         config_entry: StiebelEltronConfigEntry,
         description: StiebelEltronISGButtonDescription,
     ) -> None:

--- a/custom_components/stiebel_eltron_isg/button.py
+++ b/custom_components/stiebel_eltron_isg/button.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory
@@ -73,7 +73,8 @@ class StiebelEltronISGButtonEntity(StiebelEltronISGEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Trigger the button action."""
-        await self.entity_description.press_action(self.coordinator)  # type: ignore[attr-defined]
+        description = cast(StiebelEltronISGButtonDescription, self.entity_description)
+        await description.press_action(self.coordinator)
 
     @property
     def entity_registry_enabled_default(self) -> bool:

--- a/custom_components/stiebel_eltron_isg/climate.py
+++ b/custom_components/stiebel_eltron_isg/climate.py
@@ -21,7 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pystiebeleltron import ControllerModel
 
-from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
+from .coordinator import AnyStiebelEltronDataCoordinator, StiebelEltronConfigEntry
 from .entity import OptimisticValueMixin, StiebelEltronISGEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -336,7 +336,7 @@ class StiebelEltronISGClimateEntity(
 
     def __init__(
         self,
-        coordinator: StiebelEltronDataCoordinator,
+        coordinator: AnyStiebelEltronDataCoordinator,
         config_entry: StiebelEltronConfigEntry,
         description: StiebelEltronClimateEntityDescription,
     ) -> None:
@@ -459,7 +459,7 @@ class StiebelEltronWPMClimateEntity(StiebelEltronISGClimateEntity):
 
     def __init__(
         self,
-        coordinator: StiebelEltronDataCoordinator,
+        coordinator: AnyStiebelEltronDataCoordinator,
         config_entry: StiebelEltronConfigEntry,
         description: StiebelEltronClimateEntityDescription,
     ) -> None:
@@ -510,7 +510,7 @@ class StiebelEltronLWZClimateEntity(StiebelEltronISGClimateEntity):
 
     def __init__(
         self,
-        coordinator: StiebelEltronDataCoordinator,
+        coordinator: AnyStiebelEltronDataCoordinator,
         config_entry: StiebelEltronConfigEntry,
         description: StiebelEltronClimateEntityDescription,
     ) -> None:

--- a/custom_components/stiebel_eltron_isg/coordinator.py
+++ b/custom_components/stiebel_eltron_isg/coordinator.py
@@ -27,6 +27,9 @@ from custom_components.stiebel_eltron_isg.const import (
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
+# Entity accessors reach model-specific API attributes that the shared protocol
+# cannot express. Keep that erasure at the config-entry boundary while the
+# coordinator's own interface and data remain typed.
 type AnyStiebelEltronDataCoordinator = StiebelEltronDataCoordinator[Any]
 type StiebelEltronConfigEntry = ConfigEntry[AnyStiebelEltronDataCoordinator]
 
@@ -66,7 +69,9 @@ class StiebelEltronConnectionParams:
     connection: ModbusConnection
 
 
-class StiebelEltronDataCoordinator[T: StiebelEltronApi](DataUpdateCoordinator):
+class StiebelEltronDataCoordinator[T: StiebelEltronApi](
+    DataUpdateCoordinator[dict[Any, float | int | None]]
+):
     """Data coordinator base class for stiebel eltron isg."""
 
     def __init__(

--- a/custom_components/stiebel_eltron_isg/coordinator.py
+++ b/custom_components/stiebel_eltron_isg/coordinator.py
@@ -15,9 +15,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from modbus_connection import ModbusConnection, ModbusUnit
+from modbus_connection import ModbusConnection, ModbusError, ModbusUnit
 from modbus_connection.cli_helper import field_rows
-from pystiebeleltron import ControllerModel, ModbusError, StiebelEltronModbusError
+from pystiebeleltron import ControllerModel, StiebelEltronModbusError
 
 from custom_components.stiebel_eltron_isg.const import (
     ATTR_MANUFACTURER,
@@ -27,7 +27,8 @@ from custom_components.stiebel_eltron_isg.const import (
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
-type StiebelEltronConfigEntry = ConfigEntry[StiebelEltronDataCoordinator]
+type AnyStiebelEltronDataCoordinator = StiebelEltronDataCoordinator[Any]
+type StiebelEltronConfigEntry = ConfigEntry[AnyStiebelEltronDataCoordinator]
 
 
 def _is_read_only_write_error(err: AttributeError, field: str) -> bool:
@@ -144,9 +145,9 @@ class StiebelEltronDataCoordinator[T: StiebelEltronApi](DataUpdateCoordinator):
         # Fall back to the enum name for a clear, readable representation
         return f"other model ({self._model.name})"
 
-    def get_raw_data(self) -> dict:
+    def get_raw_data(self) -> dict[str, Any]:
         """Return the raw data from the heat pump."""
-        result: dict = {}
+        result: dict[str, Any] = {}
         for component in vars(self._api).values():
             component_result = dict(field_rows(component))
             result = {**result, **component_result}

--- a/custom_components/stiebel_eltron_isg/coordinator.py
+++ b/custom_components/stiebel_eltron_isg/coordinator.py
@@ -28,8 +28,8 @@ from custom_components.stiebel_eltron_isg.const import (
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 # Entity accessors reach model-specific API attributes that the shared protocol
-# cannot express. Keep that erasure at the config-entry boundary while the
-# coordinator's own interface and data remain typed.
+# cannot express. Keep that erasure at the shared coordinator/config-entry
+# boundary while the coordinator's own interface and data remain typed.
 type AnyStiebelEltronDataCoordinator = StiebelEltronDataCoordinator[Any]
 type StiebelEltronConfigEntry = ConfigEntry[AnyStiebelEltronDataCoordinator]
 
@@ -70,7 +70,7 @@ class StiebelEltronConnectionParams:
 
 
 class StiebelEltronDataCoordinator[T: StiebelEltronApi](
-    DataUpdateCoordinator[dict[Any, float | int | None]]
+    DataUpdateCoordinator[dict[str, float | int | None]]
 ):
     """Data coordinator base class for stiebel eltron isg."""
 
@@ -158,7 +158,7 @@ class StiebelEltronDataCoordinator[T: StiebelEltronApi](
             result = {**result, **component_result}
         return result
 
-    async def _async_update_data(self) -> dict[Any, float | int | None]:
+    async def _async_update_data(self) -> dict[str, float | int | None]:
         """Time to update."""
         self._refresh_generation += 1
         generation = self._refresh_generation

--- a/custom_components/stiebel_eltron_isg/entity.py
+++ b/custom_components/stiebel_eltron_isg/entity.py
@@ -8,12 +8,12 @@ from homeassistant.core import callback
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
+from .coordinator import AnyStiebelEltronDataCoordinator, StiebelEltronConfigEntry
 
 # At runtime this must remain ``object``: concrete entities place the mixin
 # before StiebelEltronISGEntity so ``super()`` reaches CoordinatorEntity.
 if TYPE_CHECKING:
-    _OptimisticValueMixinBase = CoordinatorEntity[StiebelEltronDataCoordinator]
+    _OptimisticValueMixinBase = CoordinatorEntity[AnyStiebelEltronDataCoordinator]
 else:
     _OptimisticValueMixinBase = object
 
@@ -68,7 +68,7 @@ class OptimisticValueMixin(_OptimisticValueMixinBase):
         super()._handle_coordinator_update()
 
 
-class StiebelEltronISGEntity(CoordinatorEntity[StiebelEltronDataCoordinator]):
+class StiebelEltronISGEntity(CoordinatorEntity[AnyStiebelEltronDataCoordinator]):
     """stiebel_eltron_isg entity base class."""
 
     _attr_has_entity_name = True
@@ -76,7 +76,7 @@ class StiebelEltronISGEntity(CoordinatorEntity[StiebelEltronDataCoordinator]):
 
     def __init__(
         self,
-        coordinator: StiebelEltronDataCoordinator,
+        coordinator: AnyStiebelEltronDataCoordinator,
         config_entry: StiebelEltronConfigEntry,
     ):
         """Initialize the entity base class."""

--- a/custom_components/stiebel_eltron_isg/migration.py
+++ b/custom_components/stiebel_eltron_isg/migration.py
@@ -12,7 +12,7 @@ rename can change again.
 """
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
@@ -81,7 +81,7 @@ def _legacy_name(entry: StiebelEltronConfigEntry) -> str:
     instead of guessed. The title is the same fallback the setup code used for
     an entry without a configured name.
     """
-    return entry.data.get(CONF_NAME, entry.title)
+    return cast(str, entry.data.get(CONF_NAME, entry.title))
 
 
 def _legacy_prefixes(

--- a/custom_components/stiebel_eltron_isg/number.py
+++ b/custom_components/stiebel_eltron_isg/number.py
@@ -42,7 +42,7 @@ from .const import (
     HEATING_CURVE_RISE_HK2,
     HEATING_CURVE_RISE_HK3,
 )
-from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
+from .coordinator import AnyStiebelEltronDataCoordinator, StiebelEltronConfigEntry
 from .entity import OptimisticValueMixin, StiebelEltronISGEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -497,7 +497,7 @@ class StiebelEltronISGNumberEntity(
 
     def __init__(
         self,
-        coordinator: StiebelEltronDataCoordinator,
+        coordinator: AnyStiebelEltronDataCoordinator,
         config_entry: StiebelEltronConfigEntry,
         description: StiebelEltronNumberEntityDescription,
     ):

--- a/custom_components/stiebel_eltron_isg/select.py
+++ b/custom_components/stiebel_eltron_isg/select.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pystiebeleltron import ControllerModel
 
 from .const import OPERATION_MODE
-from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
+from .coordinator import AnyStiebelEltronDataCoordinator, StiebelEltronConfigEntry
 from .entity import OptimisticValueMixin, StiebelEltronISGEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -127,7 +127,7 @@ class StiebelEltronISGSelectEntity(
 
     def __init__(
         self,
-        coordinator: StiebelEltronDataCoordinator,
+        coordinator: AnyStiebelEltronDataCoordinator,
         config_entry: StiebelEltronConfigEntry,
         description: StiebelEltronSelectEntityDescription,
     ):

--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -148,7 +148,7 @@ from .const import (
     VOLUME_STREAM_WP1,
     VOLUME_STREAM_WP2,
 )
-from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
+from .coordinator import AnyStiebelEltronDataCoordinator, StiebelEltronConfigEntry
 from .entity import StiebelEltronISGEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -1293,7 +1293,7 @@ class StiebelEltronISGSensor(StiebelEltronISGEntity, SensorEntity):
 
     def __init__(
         self,
-        coordinator: StiebelEltronDataCoordinator,
+        coordinator: AnyStiebelEltronDataCoordinator,
         config_entry: StiebelEltronConfigEntry,
         description: StiebelEltronSensorEntityDescription,
     ):

--- a/custom_components/stiebel_eltron_isg/switch.py
+++ b/custom_components/stiebel_eltron_isg/switch.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import SG_READY_ACTIVE, SG_READY_INPUT_1, SG_READY_INPUT_2
-from .coordinator import StiebelEltronConfigEntry, StiebelEltronDataCoordinator
+from .coordinator import AnyStiebelEltronDataCoordinator, StiebelEltronConfigEntry
 from .entity import StiebelEltronISGEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -92,7 +92,7 @@ class StiebelEltronISGSwitch(StiebelEltronISGEntity, SwitchEntity):
 
     def __init__(
         self,
-        coordinator: StiebelEltronDataCoordinator,
+        coordinator: AnyStiebelEltronDataCoordinator,
         config_entry: StiebelEltronConfigEntry,
         description: StiebelEltronSwitchEntityDescription,
     ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,22 +138,7 @@ split-on-trailing-comma = false
 "tests/**" = ["D", "SLF001"]
 
 [tool.mypy]
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
 files = ["custom_components/stiebel_eltron_isg"]
-ignore_missing_imports = false
-no_implicit_optional = true
-python_version = "3.14"
 native_parser = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-
-[[tool.mypy.overrides]]
-# pystiebeleltron 0.6.2 has inline annotations but does not publish a py.typed
-# marker. Remove this override after the separately reviewed typed release.
-module = [
-  "pystiebeleltron",
-  "pystiebeleltron.*",
-]
-ignore_missing_imports = true
+python_version = "3.14"
+strict = true

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from modbus_connection import ModbusError
+import pystiebeleltron
 from pystiebeleltron import ControllerModel, StiebelEltronModbusError
 import pytest
 
@@ -27,6 +28,11 @@ from custom_components.stiebel_eltron_isg.sensor import (
 from custom_components.stiebel_eltron_isg.wpm3i_coordinator import (
     StiebelEltronModbusWPM3iDataCoordinator,
 )
+
+
+def test_library_modbus_error_is_the_transport_error() -> None:
+    """The direct transport import must catch the library's re-exported error."""
+    assert pystiebeleltron.ModbusError is ModbusError
 
 
 def _coordinator(api) -> StiebelEltronDataCoordinator:


### PR DESCRIPTION
The existing mypy gate still uses a partial option set and excludes `pystiebeleltron` from import checking.
Version 0.7.0 now ships a `py.typed` marker, so the integration can enable mypy strict mode across all 18 source files.

The coordinator data remains typed as `dict[str, float | int | None]`.
Model-specific API types are erased only at the shared coordinator/config-entry boundary.
Platform annotations are updated, the remaining button suppression is removed, and the transport `ModbusError` import now comes from `modbus-connection`.

No runtime behavior or dependency changes are intended.

## Verification

- 935 tests passed, one expected skip, using the Home Assistant 2026.8.2 test base
- 99% total coverage, with every integration module at least 95%
- Ruff check, Ruff format, and mypy strict pass

Part of #629.

## Summary by Sourcery

Adopt strict static type checking across the integration without changing runtime behavior or dependencies.

Enhancements:
- Enable strict mypy checking across the integration and its typed external library interfaces.
- Strengthen coordinator, entity, platform, and transport error type annotations while preserving the coordinator data contract.

Tests:
- Add coverage verifying that the transport library exposes the expected Modbus error type.