### PR TITLE
Keep device identifier migration compatible with HA 2026.9

### DIFF
--- a/custom_components/stiebel_eltron_isg/migration.py
+++ b/custom_components/stiebel_eltron_isg/migration.py
@@ -230,14 +230,18 @@ def async_migrate_device_identifier(
     left behind on an empty predecessor.
     """
     registry = dr.async_get(hass)
-    legacy = registry.async_get_device(identifiers={(DOMAIN, _legacy_name(entry))})
+    legacy = _async_get_device_by_identifier(
+        registry, (DOMAIN, _legacy_name(entry)), entry.entry_id
+    )
     if legacy is None or entry.entry_id not in legacy.config_entries:
         # Nothing to migrate, or the name belongs to a second installation that
-        # happens to be called the same. Identifiers are global, so that has to
-        # be checked rather than assumed.
+        # happens to be called the same. Before Home Assistant 2026.8 identifiers
+        # are global, so ownership has to be checked rather than assumed.
         return
 
-    replacement = registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    replacement = _async_get_device_by_identifier(
+        registry, (DOMAIN, entry.entry_id), entry.entry_id
+    )
     if replacement is not None and replacement.config_entries != {entry.entry_id}:
         # Nothing here creates a device that another config entry can share, so
         # this should not happen. If it ever does, leaving both devices alone is
@@ -258,6 +262,23 @@ def async_migrate_device_identifier(
 
     registry.async_update_device(legacy.id, new_identifiers={(DOMAIN, entry.entry_id)})
     _LOGGER.info("Migrated the device identifier of %s", legacy.name)
+
+
+@callback
+def _async_get_device_by_identifier(
+    registry: dr.DeviceRegistry,
+    identifier: tuple[str, str],
+    config_entry_id: str,
+) -> dr.DeviceEntry | None:
+    """Look up one entry's device across supported Home Assistant versions."""
+    # Remove this compatibility helper once the minimum supported Home Assistant
+    # version provides the config-entry-scoped lookup.
+    if hasattr(registry, "async_get_device_by_identifier"):
+        return registry.async_get_device_by_identifier(identifier, config_entry_id)
+
+    # Home Assistant before 2026.8 only has the global identifier lookup. The
+    # caller still verifies ownership before changing the returned device.
+    return registry.async_get_device(identifiers={identifier})
 
 
 @callback

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,6 +1,7 @@
 """Tests for the migration of legacy entity unique ids."""
 
-import attr
+from typing import cast
+
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
@@ -26,6 +27,22 @@ MODEL_NAME = "Stiebel Eltron WPM_3"
 KEY = "outdoor_temperature"
 
 
+class _LegacyDeviceRegistry:
+    """Model the identifier lookup available before Home Assistant 2026.8."""
+
+    def __init__(self, device: dr.DeviceEntry) -> None:
+        """Store the device returned by the legacy global lookup."""
+        self.device = device
+        self.identifiers: set[tuple[str, str]] | None = None
+
+    def async_get_device(
+        self, identifiers: set[tuple[str, str]] | None = None
+    ) -> dr.DeviceEntry:
+        """Return the configured device and record the requested identifiers."""
+        self.identifiers = identifiers
+        return self.device
+
+
 @pytest.fixture
 def config_entry_with_name() -> MockConfigEntry:
     """Return an entry as it was created before 2026.7, with a configured name."""
@@ -35,6 +52,21 @@ def config_entry_with_name() -> MockConfigEntry:
         data={CONF_HOST: "1.1.1.1", CONF_PORT: 502, CONF_NAME: "My Heatpump"},
         entry_id="stiebel_eltron_002",
     )
+
+
+def test_device_lookup_falls_back_before_home_assistant_2026_8() -> None:
+    """The compatibility path keeps the HACS minimum version working."""
+    device = cast("dr.DeviceEntry", object())
+    legacy_registry = _LegacyDeviceRegistry(device)
+
+    result = migration._async_get_device_by_identifier(
+        cast("dr.DeviceRegistry", legacy_registry),
+        (DOMAIN, "My Heatpump"),
+        "stiebel_eltron_002",
+    )
+
+    assert result is device
+    assert legacy_registry.identifiers == {(DOMAIN, "My Heatpump")}
 
 
 def _register(
@@ -589,8 +621,8 @@ async def test_a_whole_installation_keeps_every_entity_id(
             entity_id,
             new_unique_id=legacy_prefix + unique_id.removeprefix(target_prefix),
         )
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry_with_name.entry_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
     )
     device_registry.async_update_device(
         device.id, new_identifiers={(DOMAIN, "My Heatpump")}
@@ -620,8 +652,8 @@ async def test_a_whole_installation_keeps_every_entity_id(
     }
     assert after == provided | stale
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, config_entry_with_name.entry_id)}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
         ).id
         == device.id
     )
@@ -656,15 +688,18 @@ async def test_the_device_is_renamed_rather_than_replaced(
     assert await hass.config_entries.async_setup(config_entry_with_name.entry_id)
     await hass.async_block_till_done()
 
-    migrated = device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry_with_name.entry_id)}
+    migrated = device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
     )
     assert migrated is not None
     assert migrated.id == legacy.id
     assert migrated.name_by_user == "Waermepumpe Keller"
     # No second device is left behind.
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, "My Heatpump")}) is None
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "My Heatpump"), config_entry_with_name.entry_id
+        )
+        is None
     )
     assert (
         len(
@@ -679,7 +714,7 @@ async def test_the_device_is_renamed_rather_than_replaced(
 async def test_a_device_of_another_entry_with_the_same_name_is_left_alone(
     hass: HomeAssistant, config_entry_with_name: MockConfigEntry
 ) -> None:
-    """Device identifiers are global, so the owner has to be checked.
+    """Global identifiers before Home Assistant 2026.8 require an owner check.
 
     Two installations can carry the same configured name, and only one of them
     can own the device that name produced. Home Assistant sets up every config
@@ -709,8 +744,8 @@ async def test_a_device_of_another_entry_with_the_same_name_is_left_alone(
     assert still_theirs.config_entries == {other_entry.entry_id}
     assert (DOMAIN, config_entry_with_name.entry_id) not in still_theirs.identifiers
     # Our own entry got a device of its own rather than adopting theirs.
-    ours = device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry_with_name.entry_id)}
+    ours = device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
     )
     assert ours is not None
     assert ours.id != foreign.id
@@ -812,8 +847,8 @@ async def test_labels_of_the_replacement_device_are_kept(
     assert await hass.config_entries.async_setup(config_entry_with_name.entry_id)
     await hass.async_block_till_done()
 
-    restored = device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry_with_name.entry_id)}
+    restored = device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
     )
     assert restored.id == legacy.id
     assert restored.labels == {"keller", "waermepumpe"}
@@ -846,8 +881,8 @@ async def test_a_disabled_replacement_device_does_not_disable_the_original(
     assert await hass.config_entries.async_setup(config_entry_with_name.entry_id)
     await hass.async_block_till_done()
 
-    restored = device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry_with_name.entry_id)}
+    restored = device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
     )
     assert restored.id == legacy.id
     assert restored.disabled_by is None
@@ -860,15 +895,11 @@ async def test_a_shared_replacement_device_is_left_alone(
 ) -> None:
     """A device another config entry also belongs to is never removed.
 
-    Home Assistant 2026.8 splits a shared device into one device per config
-    entry and synthesizes the former shared device from those splits. Older
-    releases store the config entries directly on one device. Removing either
-    representation would take somebody else's device with it.
+    Home Assistant 2026.8 stores one device per config entry, so only this
+    entry's replacement may be adopted. Older releases store the config entries
+    directly on one device, which must remain untouched when it is shared.
     """
     config_entry_with_name.add_to_hass(hass)
-    # Identifier lookups prefer config entries whose domain matches the
-    # identifier. Use two entries of this integration so Home Assistant can
-    # resolve their split devices back to the shared composite.
     stranger = MockConfigEntry(domain=DOMAIN, title="Something else")
     stranger.add_to_hass(hass)
     device_registry = dr.async_get(hass)
@@ -882,49 +913,41 @@ async def test_a_shared_replacement_device_is_left_alone(
         identifiers={(DOMAIN, config_entry_with_name.entry_id)},
         name=MODEL_NAME,
     )
-    expected_shared_id = replacement.id
-    protected_device_ids = {replacement.id}
-    if hasattr(dr.DeviceEntry, "composite_device_id"):
+    if hasattr(device_registry, "async_get_device_by_identifier"):
         stranger_replacement = device_registry.async_get_or_create(
             config_entry_id=stranger.entry_id,
-            identifiers={(DOMAIN, f"{config_entry_with_name.entry_id}_stranger")},
+            identifiers={(DOMAIN, config_entry_with_name.entry_id)},
             name=MODEL_NAME,
         )
-        composite_id = "pre_split_replacement_device"
-        expected_shared_id = composite_id
-        device_registry.devices[replacement.id] = attr.evolve(
-            replacement, composite_device_id=composite_id
+        assert (
+            device_registry.async_get_device_by_identifier(
+                (DOMAIN, config_entry_with_name.entry_id),
+                config_entry_with_name.entry_id,
+            )
+            == replacement
         )
-        device_registry.devices[stranger_replacement.id] = attr.evolve(
-            stranger_replacement,
-            composite_device_id=composite_id,
-            identifiers={(DOMAIN, config_entry_with_name.entry_id)},
+        assert (
+            device_registry.async_get_device_by_identifier(
+                (DOMAIN, config_entry_with_name.entry_id), stranger.entry_id
+            )
+            == stranger_replacement
         )
-        protected_device_ids.add(stranger_replacement.id)
     else:
         device_registry.async_update_device(
             replacement.id, add_config_entry_id=stranger.entry_id
         )
-
-    shared_replacement = device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry_with_name.entry_id)}
-    )
-    assert shared_replacement is not None
-    assert shared_replacement.id == expected_shared_id
-    assert shared_replacement.config_entries == {
-        config_entry_with_name.entry_id,
-        stranger.entry_id,
-    }
+        stranger_replacement = replacement
 
     assert await hass.config_entries.async_setup(config_entry_with_name.entry_id)
     await hass.async_block_till_done()
 
-    assert all(
-        device_registry.async_get(device_id) is not None
-        for device_id in protected_device_ids
-    )
+    assert device_registry.async_get(stranger_replacement.id) is not None
     assert device_registry.async_get(legacy.id) is not None
-    assert "shared with" in caplog.text
+    if stranger_replacement.id == replacement.id:
+        assert "shared with" in caplog.text
+    else:
+        assert device_registry.async_get(replacement.id) is None
+        assert "shared with" not in caplog.text
 
 
 async def test_a_disabled_or_customised_entity_keeps_everything(
@@ -985,8 +1008,8 @@ async def test_an_area_set_after_the_update_is_carried_over(
     assert await hass.config_entries.async_setup(config_entry_with_name.entry_id)
     await hass.async_block_till_done()
 
-    restored = device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry_with_name.entry_id)}
+    restored = device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
     )
     assert restored.id == legacy.id
     assert restored.area_id == "heizungskeller"

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -43,6 +43,17 @@ class _LegacyDeviceRegistry:
         return self.device
 
 
+def _get_device_by_identifier(
+    registry: dr.DeviceRegistry,
+    identifier: tuple[str, str],
+    config_entry_id: str,
+) -> dr.DeviceEntry | None:
+    """Look up a test device across supported Home Assistant versions."""
+    if hasattr(registry, "async_get_device_by_identifier"):
+        return registry.async_get_device_by_identifier(identifier, config_entry_id)
+    return registry.async_get_device(identifiers={identifier})
+
+
 @pytest.fixture
 def config_entry_with_name() -> MockConfigEntry:
     """Return an entry as it was created before 2026.7, with a configured name."""
@@ -621,8 +632,10 @@ async def test_a_whole_installation_keeps_every_entity_id(
             entity_id,
             new_unique_id=legacy_prefix + unique_id.removeprefix(target_prefix),
         )
-    device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
+    device = _get_device_by_identifier(
+        device_registry,
+        (DOMAIN, config_entry_with_name.entry_id),
+        config_entry_with_name.entry_id,
     )
     device_registry.async_update_device(
         device.id, new_identifiers={(DOMAIN, "My Heatpump")}
@@ -652,8 +665,10 @@ async def test_a_whole_installation_keeps_every_entity_id(
     }
     assert after == provided | stale
     assert (
-        device_registry.async_get_device_by_identifier(
-            (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
+        _get_device_by_identifier(
+            device_registry,
+            (DOMAIN, config_entry_with_name.entry_id),
+            config_entry_with_name.entry_id,
         ).id
         == device.id
     )
@@ -688,16 +703,18 @@ async def test_the_device_is_renamed_rather_than_replaced(
     assert await hass.config_entries.async_setup(config_entry_with_name.entry_id)
     await hass.async_block_till_done()
 
-    migrated = device_registry.async_get_device_by_identifier(
-        (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
+    migrated = _get_device_by_identifier(
+        device_registry,
+        (DOMAIN, config_entry_with_name.entry_id),
+        config_entry_with_name.entry_id,
     )
     assert migrated is not None
     assert migrated.id == legacy.id
     assert migrated.name_by_user == "Waermepumpe Keller"
     # No second device is left behind.
     assert (
-        device_registry.async_get_device_by_identifier(
-            (DOMAIN, "My Heatpump"), config_entry_with_name.entry_id
+        _get_device_by_identifier(
+            device_registry, (DOMAIN, "My Heatpump"), config_entry_with_name.entry_id
         )
         is None
     )
@@ -744,8 +761,10 @@ async def test_a_device_of_another_entry_with_the_same_name_is_left_alone(
     assert still_theirs.config_entries == {other_entry.entry_id}
     assert (DOMAIN, config_entry_with_name.entry_id) not in still_theirs.identifiers
     # Our own entry got a device of its own rather than adopting theirs.
-    ours = device_registry.async_get_device_by_identifier(
-        (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
+    ours = _get_device_by_identifier(
+        device_registry,
+        (DOMAIN, config_entry_with_name.entry_id),
+        config_entry_with_name.entry_id,
     )
     assert ours is not None
     assert ours.id != foreign.id
@@ -847,8 +866,10 @@ async def test_labels_of_the_replacement_device_are_kept(
     assert await hass.config_entries.async_setup(config_entry_with_name.entry_id)
     await hass.async_block_till_done()
 
-    restored = device_registry.async_get_device_by_identifier(
-        (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
+    restored = _get_device_by_identifier(
+        device_registry,
+        (DOMAIN, config_entry_with_name.entry_id),
+        config_entry_with_name.entry_id,
     )
     assert restored.id == legacy.id
     assert restored.labels == {"keller", "waermepumpe"}
@@ -881,8 +902,10 @@ async def test_a_disabled_replacement_device_does_not_disable_the_original(
     assert await hass.config_entries.async_setup(config_entry_with_name.entry_id)
     await hass.async_block_till_done()
 
-    restored = device_registry.async_get_device_by_identifier(
-        (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
+    restored = _get_device_by_identifier(
+        device_registry,
+        (DOMAIN, config_entry_with_name.entry_id),
+        config_entry_with_name.entry_id,
     )
     assert restored.id == legacy.id
     assert restored.disabled_by is None
@@ -1008,8 +1031,10 @@ async def test_an_area_set_after_the_update_is_carried_over(
     assert await hass.config_entries.async_setup(config_entry_with_name.entry_id)
     await hass.async_block_till_done()
 
-    restored = device_registry.async_get_device_by_identifier(
-        (DOMAIN, config_entry_with_name.entry_id), config_entry_with_name.entry_id
+    restored = _get_device_by_identifier(
+        device_registry,
+        (DOMAIN, config_entry_with_name.entry_id),
+        config_entry_with_name.entry_id,
     )
     assert restored.id == legacy.id
     assert restored.area_id == "heizungskeller"


### PR DESCRIPTION
HA 2026.9 makes the device registry identifier mapping read-only and deprecates the global lookup helpers, which broke the device identifier migration and its tests under pytest-homeassistant-custom-component 0.13.359 / HA 2026.9.0b1.

Changes:

- Use the config-entry-scoped `async_get_device_by_identifier` API on HA 2026.8+.
  Besides fixing the deprecation, this prevents the migration from selecting a device belonging to another config entry when old names collide.
- Keep the legacy lookup path as a tested fallback, since `hacs.json` still declares HA 2025.8 as the minimum supported version.
- Rewrite the affected tests so they no longer mutate the registry mapping directly.

Verification:

- HA 2026.9.0b1: 939 tests, one expected skip, 99% coverage.
- HA 2026.8.2: 938 passed, one expected skip.
- Ruff, format, strict mypy and diff check pass.

Related: #676 is the dependency update that exposed these failures.

## Summary by Sourcery

Maintain safe, cross-version device identifier migration across Home Assistant device registry API changes.

Bug Fixes:
- Keep device identifier migration working with Home Assistant 2026.9 while preserving support for older supported releases.
- Prevent migrations from adopting a same-named device belonging to another config entry.

Enhancements:
- Use config-entry-scoped device lookups when available and retain a compatibility fallback for older Home Assistant versions.

Tests:
- Update migration tests for current device registry APIs without directly mutating registry internals.
- Add coverage for the legacy device lookup compatibility path.