### PR TITLE
Hide unsupported WPMsystem runtime sensors

### DIFF
--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -31,6 +31,7 @@ from .migration import (
     async_migrate_device_identifier,
     async_migrate_unique_ids,
     async_remove_legacy_circulation_pump_switch,
+    async_remove_unsupported_wpmsystem_runtime_sensors,
     duplicate_entity_issue_id,
 )
 from .wpm3i_coordinator import StiebelEltronModbusWPM3iDataCoordinator
@@ -153,6 +154,10 @@ async def async_setup_entry(
     # added to the registry entries and the device that already carry their new
     # identifiers.
     async_migrate_device_identifier(hass, entry)
+    # Before the unique id migration, so that an entity about to be deleted is
+    # never planned, never counted as a duplicate, and never reported by the
+    # Repair the migration raises for the duplicates it finds.
+    async_remove_unsupported_wpmsystem_runtime_sensors(hass, entry, model)
     await async_migrate_unique_ids(hass, entry, model)
     async_remove_legacy_circulation_pump_switch(hass, entry, model)
 

--- a/custom_components/stiebel_eltron_isg/migration.py
+++ b/custom_components/stiebel_eltron_isg/migration.py
@@ -23,7 +23,14 @@ from homeassistant.helpers import (
 )
 from pystiebeleltron import ControllerModel
 
-from .const import CIRCULATION_PUMP, DOMAIN, HEATER_PRESSURE
+from .const import (
+    CIRCULATION_PUMP,
+    COMPRESSOR_HEATING,
+    COMPRESSOR_HEATING_WATER,
+    COOLING_RUNTIME,
+    DOMAIN,
+    HEATER_PRESSURE,
+)
 from .coordinator import StiebelEltronConfigEntry, coordinator_display_name
 from .entity import build_unique_id
 
@@ -69,6 +76,68 @@ def async_remove_legacy_circulation_pump_switch(
     if obsolete:
         _LOGGER.info(
             "Removed %s obsolete circulation pump switch entities",
+            len(obsolete),
+        )
+
+
+# The three aggregate runtime sensors a WPMsystem cannot serve, see issue #612.
+# Their registry entries survive the entity no longer being created, so without
+# this they stay behind as unavailable, which is the state the issue is about.
+_WPMSYSTEM_UNSUPPORTED_RUNTIME_KEYS = (
+    COMPRESSOR_HEATING,
+    COMPRESSOR_HEATING_WATER,
+    COOLING_RUNTIME,
+)
+
+
+@callback
+def async_remove_unsupported_wpmsystem_runtime_sensors(
+    hass: HomeAssistant,
+    entry: StiebelEltronConfigEntry,
+    model: ControllerModel,
+) -> None:
+    """Remove the runtime sensors a WPMsystem never answers.
+
+    Nothing is lost. The registers reply with the unavailable marker on this
+    controller, so the entities never held a numeric state and no statistic was
+    recorded for them. Removing a registry entry does not discard recorder
+    history either, so a controller that was replaced by a WPMsystem keeps what
+    it had recorded before.
+    """
+    if model is not ControllerModel.WPMsystem:
+        return
+
+    registry = er.async_get(hass)
+    # Every model prefix, not only the one detected now: a controller that was
+    # replaced by a WPMsystem left ids carrying the name of the model it was
+    # detected as back then, and nothing will ever provide those entities again.
+    prefixes = _legacy_prefixes(entry, model) + [
+        f"{DOMAIN}_{coordinator_display_name(historical)}_"
+        for historical in ControllerModel
+    ]
+    obsolete_unique_ids = {
+        unique_id
+        for key in _WPMSYSTEM_UNSUPPORTED_RUNTIME_KEYS
+        for unique_id in (
+            build_unique_id(entry, key),
+            *(f"{prefix}{key}" for prefix in prefixes),
+        )
+    }
+    obsolete = [
+        registry_entry
+        for registry_entry in er.async_entries_for_config_entry(
+            registry,
+            entry.entry_id,
+        )
+        if registry_entry.domain == "sensor"
+        and registry_entry.unique_id in obsolete_unique_ids
+    ]
+    for registry_entry in obsolete:
+        registry.async_remove(registry_entry.entity_id)
+
+    if obsolete:
+        _LOGGER.info(
+            "Removed %s runtime sensor entities this controller does not serve",
             len(obsolete),
         )
 

--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -1202,12 +1202,13 @@ WPM_SENSOR_TYPES = (
     + WPM_POWER_CONSUMPTION_SENSOR_TYPES
 )
 
-# The official register table assigns aggregate runtime wires 3516-3518 only
-# to WPM 3i. On the measured WPMsystem firmware, individual reads return
-# Modbus exception 2 and the wider energy block returns the unavailable marker,
-# so those three sensor entities could never hold a value there. This hardware-
-# backed correction is deliberately limited to WPMsystem; WPM 3 and LWZ_R290
-# keep their existing entity surface until equivalent measurements exist.
+# The aggregate runtime wires 3516-3518 are declared for every WPM variant in
+# the library, but two measured WPMsystem installations do not serve them:
+# individual reads return Modbus exception 2 and the wider energy block returns
+# the unavailable marker, so those three sensor entities could never hold a
+# value there (issue #612). This hardware-backed correction is deliberately
+# limited to WPMsystem; WPM 3 and LWZ_R290 keep their existing entity surface
+# until equivalent measurements exist.
 WPMSYSTEM_SENSOR_TYPES = WPM_BASE_SENSOR_TYPES + WPM_POWER_CONSUMPTION_SENSOR_TYPES
 
 LWZ_SENSOR_TYPES = (

--- a/custom_components/stiebel_eltron_isg/sensor.py
+++ b/custom_components/stiebel_eltron_isg/sensor.py
@@ -1192,13 +1192,23 @@ WPM_3I_SENSOR_TYPES = (
     + WPM_COMPRESSOR_SENSOR_TYPES
 )
 
+WPM_BASE_SENSOR_TYPES = (
+    SYSTEM_VALUES_SENSOR_TYPES + ENERGYMANAGEMENT_SENSOR_TYPES + ENERGY_SENSOR_TYPES
+)
+
 WPM_SENSOR_TYPES = (
-    SYSTEM_VALUES_SENSOR_TYPES
-    + ENERGYMANAGEMENT_SENSOR_TYPES
-    + ENERGY_SENSOR_TYPES
+    WPM_BASE_SENSOR_TYPES
     + WPM_COMPRESSOR_SENSOR_TYPES
     + WPM_POWER_CONSUMPTION_SENSOR_TYPES
 )
+
+# The official register table assigns aggregate runtime wires 3516-3518 only
+# to WPM 3i. On the measured WPMsystem firmware, individual reads return
+# Modbus exception 2 and the wider energy block returns the unavailable marker,
+# so those three sensor entities could never hold a value there. This hardware-
+# backed correction is deliberately limited to WPMsystem; WPM 3 and LWZ_R290
+# keep their existing entity surface until equivalent measurements exist.
+WPMSYSTEM_SENSOR_TYPES = WPM_BASE_SENSOR_TYPES + WPM_POWER_CONSUMPTION_SENSOR_TYPES
 
 LWZ_SENSOR_TYPES = (
     LWZ_SYSTEM_VALUES_SENSOR_TYPES
@@ -1241,13 +1251,18 @@ async def async_setup_entry(
         ControllerModel.WPMsystem,
         ControllerModel.LWZ_R290,
     ):
+        sensor_types = (
+            WPMSYSTEM_SENSOR_TYPES
+            if coordinator.model == ControllerModel.WPMsystem
+            else WPM_SENSOR_TYPES
+        )
         entities = [
             StiebelEltronISGSensor(
                 coordinator,
                 entry,
                 description,
             )
-            for description in WPM_SENSOR_TYPES
+            for description in sensor_types
         ]
         daily_energy_entities = [
             StiebelEltronISGSensor(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -26,6 +26,7 @@ from pytest_homeassistant_custom_component.common import (
 )
 
 from custom_components.stiebel_eltron_isg.const import (
+    COMPRESSOR_HEATING,
     CURRENT_POWER_CONSUMPTION,
     DOMAIN,
     UNIT_ID,
@@ -548,3 +549,55 @@ async def test_unload_entry_does_not_close_connection_if_platform_unload_fails(
     # so the deliberately failed unload does not leak resources from the test.
     await mock_config_entry.runtime_data.async_shutdown()
     await mock_modbus_connection.close()
+
+
+async def test_setup_removes_unsupported_wpmsystem_runtime_sensor(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_get_controller_model: MagicMock,
+) -> None:
+    """Setting up a WPMsystem clears a runtime sensor left by an earlier release."""
+    mock_get_controller_model.return_value = ControllerModel.WPMsystem
+    mock_config_entry.add_to_hass(hass)
+    stale = er.async_get(hass).async_get_or_create(
+        "sensor",
+        DOMAIN,
+        build_unique_id(mock_config_entry, COMPRESSOR_HEATING),
+        config_entry=mock_config_entry,
+        suggested_object_id=COMPRESSOR_HEATING,
+    )
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id) is True
+    await hass.async_block_till_done()
+
+    assert er.async_get(hass).async_get(stale.entity_id) is None
+
+
+async def test_removed_runtime_sensor_raises_no_duplicate_repair(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_get_controller_model: MagicMock,
+) -> None:
+    """A sensor about to be deleted must not be reported as a duplicate first."""
+    mock_get_controller_model.return_value = ControllerModel.WPMsystem
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    for unique_id, object_id in (
+        (build_unique_id(mock_config_entry, COMPRESSOR_HEATING), COMPRESSOR_HEATING),
+        (f"{DOMAIN}_Stiebel Eltron_{COMPRESSOR_HEATING}", "legacy_compressor_heating"),
+    ):
+        registry.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            config_entry=mock_config_entry,
+            suggested_object_id=object_id,
+        )
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id) is True
+    await hass.async_block_till_done()
+
+    issue = ir.async_get(hass).async_get_issue(
+        DOMAIN, duplicate_entity_issue_id(mock_config_entry)
+    )
+    assert issue is None

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -14,8 +14,14 @@ from pystiebeleltron import ControllerModel
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.stiebel_eltron_isg import migration
-from custom_components.stiebel_eltron_isg.const import CIRCULATION_PUMP, DOMAIN
+from custom_components.stiebel_eltron_isg import migration, sensor
+from custom_components.stiebel_eltron_isg.const import (
+    CIRCULATION_PUMP,
+    COMPRESSOR_HEATING,
+    COMPRESSOR_HEATING_WATER,
+    COOLING_RUNTIME,
+    DOMAIN,
+)
 from custom_components.stiebel_eltron_isg.entity import build_unique_id
 
 # The model the mock_get_controller_model fixture reports, and the display name
@@ -1061,3 +1067,165 @@ async def test_migration_is_idempotent(
     migrated = er.async_get(hass).async_get(legacy.entity_id)
     assert migrated.entity_id == "sensor.stiebel_eltron_isg_outdoor_temperature"
     assert migrated.unique_id == f"{config_entry_with_name.entry_id}_{KEY}"
+
+
+def test_removes_unsupported_wpmsystem_runtime_sensors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A WPMsystem must not keep the three sensors it can never serve."""
+    mock_config_entry.add_to_hass(hass)
+    obsolete = [
+        _register(
+            hass,
+            mock_config_entry,
+            build_unique_id(mock_config_entry, key),
+            key,
+        )
+        for key in (COMPRESSOR_HEATING, COMPRESSOR_HEATING_WATER, COOLING_RUNTIME)
+    ]
+
+    migration.async_remove_unsupported_wpmsystem_runtime_sensors(
+        hass,
+        mock_config_entry,
+        ControllerModel.WPMsystem,
+    )
+
+    registry = er.async_get(hass)
+    assert [registry.async_get(entry.entity_id) for entry in obsolete] == [None] * 3
+
+
+def test_removes_unsupported_runtime_sensors_on_legacy_unique_ids(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """An entry left on either historical unique-id scheme is removed too."""
+    mock_config_entry.add_to_hass(hass)
+    legacy = _register(
+        hass,
+        mock_config_entry,
+        f"{DOMAIN}_Stiebel Eltron_{COMPRESSOR_HEATING}",
+        "legacy_compressor_heating",
+    )
+    model_legacy = _register(
+        hass,
+        mock_config_entry,
+        f"{DOMAIN}_Stiebel Eltron WPMsystem_{COMPRESSOR_HEATING}",
+        "model_legacy_compressor_heating",
+    )
+
+    migration.async_remove_unsupported_wpmsystem_runtime_sensors(
+        hass,
+        mock_config_entry,
+        ControllerModel.WPMsystem,
+    )
+
+    registry = er.async_get(hass)
+    assert registry.async_get(legacy.entity_id) is None
+    assert registry.async_get(model_legacy.entity_id) is None
+
+
+def test_runtime_sensor_cleanup_leaves_other_models_untouched(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A WPM 3i answers these registers, so its entities have to survive."""
+    mock_config_entry.add_to_hass(hass)
+    kept = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(mock_config_entry, COMPRESSOR_HEATING),
+        COMPRESSOR_HEATING,
+    )
+
+    migration.async_remove_unsupported_wpmsystem_runtime_sensors(
+        hass,
+        mock_config_entry,
+        ControllerModel.WPM_3i,
+    )
+
+    assert er.async_get(hass).async_get(kept.entity_id) is not None
+
+
+def test_runtime_sensor_cleanup_leaves_unrelated_entities_untouched(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Neither another sensor nor a switch sharing the key may be removed."""
+    mock_config_entry.add_to_hass(hass)
+    other_sensor = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(mock_config_entry, KEY),
+        KEY,
+    )
+    same_key_switch = _register(
+        hass,
+        mock_config_entry,
+        build_unique_id(mock_config_entry, COMPRESSOR_HEATING),
+        "compressor_heating_switch",
+        domain="switch",
+    )
+
+    migration.async_remove_unsupported_wpmsystem_runtime_sensors(
+        hass,
+        mock_config_entry,
+        ControllerModel.WPMsystem,
+    )
+
+    registry = er.async_get(hass)
+    assert registry.async_get(other_sensor.entity_id) is not None
+    assert registry.async_get(same_key_switch.entity_id) is not None
+
+
+def test_removed_runtime_keys_match_the_sensors_wpmsystem_omits() -> None:
+    """The cleanup must cover exactly the keys the sensor platform drops."""
+    omitted = {description.key for description in sensor.WPM_SENSOR_TYPES} - {
+        description.key for description in sensor.WPMSYSTEM_SENSOR_TYPES
+    }
+
+    assert set(migration._WPMSYSTEM_UNSUPPORTED_RUNTIME_KEYS) == omitted
+
+
+def test_runtime_sensor_cleanup_covers_the_configured_name_scheme(
+    hass: HomeAssistant,
+    config_entry_with_name: MockConfigEntry,
+) -> None:
+    """The oldest ids were built from the name the user had configured."""
+    config_entry_with_name.add_to_hass(hass)
+    legacy = _register(
+        hass,
+        config_entry_with_name,
+        f"{DOMAIN}_My Heatpump_{COOLING_RUNTIME}",
+        "legacy_cooling_runtime",
+    )
+
+    migration.async_remove_unsupported_wpmsystem_runtime_sensors(
+        hass,
+        config_entry_with_name,
+        ControllerModel.WPMsystem,
+    )
+
+    assert er.async_get(hass).async_get(legacy.entity_id) is None
+
+
+def test_runtime_sensor_cleanup_covers_a_previously_detected_model(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A controller swapped for a WPMsystem left ids naming the old model."""
+    mock_config_entry.add_to_hass(hass)
+    previous_model = _register(
+        hass,
+        mock_config_entry,
+        f"{DOMAIN}_Stiebel Eltron WPM_3i_{COMPRESSOR_HEATING}",
+        "wpm_3i_compressor_heating",
+    )
+
+    migration.async_remove_unsupported_wpmsystem_runtime_sensors(
+        hass,
+        mock_config_entry,
+        ControllerModel.WPMsystem,
+    )
+
+    assert er.async_get(hass).async_get(previous_model.entity_id) is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -75,6 +75,7 @@ from custom_components.stiebel_eltron_isg.sensor import (
     WPM_3I_SENSOR_TYPES,
     WPM_INVERTER_POWER_SENSOR_TYPES,
     WPM_SENSOR_TYPES,
+    WPMSYSTEM_SENSOR_TYPES,
     StiebelEltronISGSensor,
     StiebelEltronSensorEntityDescription,
     async_setup_entry,
@@ -221,13 +222,9 @@ def test_sensor_description_rejects_non_callable_register() -> None:
         )
 
 
-async def test_setup_uses_wpm_3i_sensor_lists() -> None:
-    """WPM 3i receives both its regular and daily energy sensors."""
-    entry = SimpleNamespace(
-        runtime_data=SimpleNamespace(model=ControllerModel.WPM_3i),
-    )
+async def _setup_sensor_keys(model: ControllerModel) -> list[str]:
+    entry = SimpleNamespace(runtime_data=SimpleNamespace(model=model))
     add_entities = MagicMock()
-
     with patch.object(
         sensor_module,
         "StiebelEltronISGSensor",
@@ -237,15 +234,49 @@ async def test_setup_uses_wpm_3i_sensor_lists() -> None:
         ),
     ):
         await sensor_module.async_setup_entry(None, entry, add_entities)
+    return [key for _, key in add_entities.call_args.args[0]]
 
-    entities = add_entities.call_args.args[0]
-    assert entities == [
-        *[("sensor", description.key) for description in WPM_3I_SENSOR_TYPES],
-        *[
-            ("sensor", description.key)
-            for description in sensor_module.ENERGY_DAILY_SENSOR_TYPES
-        ],
+
+async def test_setup_uses_wpm_3i_sensor_lists() -> None:
+    """WPM 3i receives both its regular and daily energy sensors."""
+    entity_keys = await _setup_sensor_keys(ControllerModel.WPM_3i)
+
+    assert entity_keys == [
+        *[description.key for description in WPM_3I_SENSOR_TYPES],
+        *[description.key for description in sensor_module.ENERGY_DAILY_SENSOR_TYPES],
     ]
+
+
+async def test_setup_omits_unsupported_wpmsystem_aggregate_runtime_sensors() -> None:
+    """WPMsystem must not create the WPM 3i-only aggregate runtime sensors."""
+    entity_keys = await _setup_sensor_keys(ControllerModel.WPMsystem)
+    unsupported_runtime_keys = {
+        COMPRESSOR_HEATING,
+        COMPRESSOR_HEATING_WATER,
+        COOLING_RUNTIME,
+    }
+    shared_keys = {description.key for description in WPM_SENSOR_TYPES}
+    wpmsystem_keys = {description.key for description in WPMSYSTEM_SENSOR_TYPES}
+
+    assert wpmsystem_keys < shared_keys
+    assert shared_keys - wpmsystem_keys == unsupported_runtime_keys
+    assert set(entity_keys) == (
+        wpmsystem_keys
+        | {description.key for description in ENERGY_DAILY_SENSOR_TYPES}
+        | {description.key for description in WPM_INVERTER_POWER_SENSOR_TYPES}
+    )
+    assert len(entity_keys) == len(set(entity_keys))
+
+
+@pytest.mark.parametrize("model", [ControllerModel.WPM_3, ControllerModel.LWZ_R290])
+async def test_wpmsystem_runtime_fix_does_not_change_unmeasured_models(model) -> None:
+    """Keep other model surfaces unchanged until their registers are measured."""
+    entity_keys = set(await _setup_sensor_keys(model))
+    assert {
+        COMPRESSOR_HEATING,
+        COMPRESSOR_HEATING_WATER,
+        COOLING_RUNTIME,
+    } <= entity_keys
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The three aggregate runtime sensors stay unavailable on the two WPMsystem installations reported in #612. Their registers return an exception or the unavailable marker, while separate per-heat-pump counters do return values.

This stops creating `compressor_heating`, `compressor_heating_water` and `cooling_runtime` for WPMsystem and removes their stale entity-registry entries, including older unique-ID formats. The cleanup runs before ID migration to avoid reporting duplicates for entities being removed. It does not delete recorder history or long-term statistics.

The scope is limited to WPMsystem. Per-heat-pump counters should be added as separate entities in a follow-up: using them for the existing aggregate sensors would change the meaning of recorded values on cascaded systems.

Tests cover sensor selection, registry cleanup, legacy IDs, migration ordering and preservation of other models and entity types. If a WPMsystem does provide the aggregate counters, please report it so this change can be narrowed.

Fixes #612.

## Summary by Sourcery

Hide unsupported WPMsystem aggregate runtime sensors and clean up their stale registry entries without changing other controller models.

Bug Fixes:
- Stop creating the three aggregate runtime sensors that WPMsystem controllers cannot provide.
- Remove stale unsupported WPMsystem runtime entities from the entity registry, including entries using historical unique-ID schemes.

Enhancements:
- Keep the existing runtime sensor surface unchanged for WPM 3, WPM 3i, and LWZ_R290 controllers.

Tests:
- Add coverage for WPMsystem sensor filtering, registry cleanup, legacy identifiers, duplicate-repair ordering, and preservation of other models and entity types.
