### PR TITLE
Translate integration setup errors

### DIFF
--- a/custom_components/stiebel_eltron_isg/__init__.py
+++ b/custom_components/stiebel_eltron_isg/__init__.py
@@ -99,12 +99,20 @@ async def async_setup_entry(
             UNIT_ID,
         )
     except HomeAssistantError as exception:
-        raise ConfigEntryError(str(exception)) from exception
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="modbus_setup_failed",
+            translation_placeholders={"error": str(exception)},
+        ) from exception
 
     try:
         model = await get_controller_model(unit)
     except StiebelEltronModbusError as exception:
-        raise ConfigEntryNotReady("Could not read controller model") from exception
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="controller_read_failed",
+            translation_placeholders={"error": str(exception)},
+        ) from exception
     except UnknownControllerModelError as exception:
         # An unrecognised controller id is a permanent condition, not a
         # transient modbus glitch: fail cleanly instead of retrying forever.
@@ -112,7 +120,9 @@ async def async_setup_entry(
         # entry anyway.
         _create_unsupported_controller_issue(hass, entry, exception.model_id)
         raise ConfigEntryError(
-            f"Unsupported controller model: {exception}"
+            translation_domain=DOMAIN,
+            translation_key="unsupported_controller",
+            translation_placeholders={"model_id": str(exception.model_id)},
         ) from exception
 
     coordinator: AnyStiebelEltronDataCoordinator
@@ -144,7 +154,11 @@ async def async_setup_entry(
         _create_unsupported_controller_issue(
             hass, entry, getattr(model, "value", model)
         )
-        raise ConfigEntryError(f"Unsupported controller model: {model}")
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="unsupported_controller",
+            translation_placeholders={"model_id": str(getattr(model, "value", model))},
+        )
 
     # A library and integration update can add the model while this repair still
     # exists from an earlier setup attempt.
@@ -163,7 +177,16 @@ async def async_setup_entry(
 
     entry.runtime_data = coordinator
 
-    await coordinator.async_config_entry_first_refresh()
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except ConfigEntryNotReady as exception:
+        # The coordinator wraps its first update failure without translation
+        # metadata. Keep the cause chain and expose a translated setup reason.
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="initial_read_failed",
+            translation_placeholders={"error": str(exception)},
+        ) from exception
 
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
 

--- a/custom_components/stiebel_eltron_isg/strings.json
+++ b/custom_components/stiebel_eltron_isg/strings.json
@@ -45,6 +45,18 @@
         }
     },
     "exceptions": {
+        "modbus_setup_failed": {
+            "message": "Could not set up the Modbus connection: {error}"
+        },
+        "controller_read_failed": {
+            "message": "Could not read the controller model: {error}"
+        },
+        "unsupported_controller": {
+            "message": "Unsupported controller model: {model_id}"
+        },
+        "initial_read_failed": {
+            "message": "Could not read the initial device data: {error}"
+        },
         "write_unsupported": {
             "message": "The setting {field} cannot be written on the connected controller."
         },

--- a/custom_components/stiebel_eltron_isg/translations/cz.json
+++ b/custom_components/stiebel_eltron_isg/translations/cz.json
@@ -40,6 +40,18 @@
         }
     },
     "exceptions": {
+        "modbus_setup_failed": {
+            "message": "Nepodařilo se nastavit připojení Modbus: {error}"
+        },
+        "controller_read_failed": {
+            "message": "Nepodařilo se přečíst model regulátoru: {error}"
+        },
+        "unsupported_controller": {
+            "message": "Nepodporovaný model regulátoru: {model_id}"
+        },
+        "initial_read_failed": {
+            "message": "Nepodařilo se přečíst počáteční data zařízení: {error}"
+        },
         "write_unsupported": {
             "message": "The setting {field} cannot be written on the connected controller."
         },

--- a/custom_components/stiebel_eltron_isg/translations/de.json
+++ b/custom_components/stiebel_eltron_isg/translations/de.json
@@ -40,6 +40,18 @@
         }
     },
     "exceptions": {
+        "modbus_setup_failed": {
+            "message": "Die Modbus-Verbindung konnte nicht eingerichtet werden: {error}"
+        },
+        "controller_read_failed": {
+            "message": "Das Reglermodell konnte nicht gelesen werden: {error}"
+        },
+        "unsupported_controller": {
+            "message": "Nicht unterstütztes Reglermodell: {model_id}"
+        },
+        "initial_read_failed": {
+            "message": "Die Gerätedaten konnten beim Start nicht gelesen werden: {error}"
+        },
         "write_unsupported": {
             "message": "Die Einstellung {field} kann bei der verbundenen Regelung nicht geschrieben werden."
         },

--- a/custom_components/stiebel_eltron_isg/translations/en.json
+++ b/custom_components/stiebel_eltron_isg/translations/en.json
@@ -45,6 +45,18 @@
         }
     },
     "exceptions": {
+        "modbus_setup_failed": {
+            "message": "Could not set up the Modbus connection: {error}"
+        },
+        "controller_read_failed": {
+            "message": "Could not read the controller model: {error}"
+        },
+        "unsupported_controller": {
+            "message": "Unsupported controller model: {model_id}"
+        },
+        "initial_read_failed": {
+            "message": "Could not read the initial device data: {error}"
+        },
         "write_unsupported": {
             "message": "The setting {field} cannot be written on the connected controller."
         },

--- a/custom_components/stiebel_eltron_isg/translations/fr.json
+++ b/custom_components/stiebel_eltron_isg/translations/fr.json
@@ -40,6 +40,18 @@
         }
     },
     "exceptions": {
+        "modbus_setup_failed": {
+            "message": "Impossible de configurer la connexion Modbus : {error}"
+        },
+        "controller_read_failed": {
+            "message": "Impossible de lire le modèle du régulateur : {error}"
+        },
+        "unsupported_controller": {
+            "message": "Modèle de régulateur non pris en charge : {model_id}"
+        },
+        "initial_read_failed": {
+            "message": "Impossible de lire les données initiales de l’appareil : {error}"
+        },
         "write_unsupported": {
             "message": "The setting {field} cannot be written on the connected controller."
         },

--- a/custom_components/stiebel_eltron_isg/translations/it.json
+++ b/custom_components/stiebel_eltron_isg/translations/it.json
@@ -40,6 +40,18 @@
         }
     },
     "exceptions": {
+        "modbus_setup_failed": {
+            "message": "Impossibile configurare la connessione Modbus: {error}"
+        },
+        "controller_read_failed": {
+            "message": "Impossibile leggere il modello del regolatore: {error}"
+        },
+        "unsupported_controller": {
+            "message": "Modello di regolatore non supportato: {model_id}"
+        },
+        "initial_read_failed": {
+            "message": "Impossibile leggere i dati iniziali del dispositivo: {error}"
+        },
         "write_unsupported": {
             "message": "The setting {field} cannot be written on the connected controller."
         },

--- a/custom_components/stiebel_eltron_isg/translations/pt.json
+++ b/custom_components/stiebel_eltron_isg/translations/pt.json
@@ -40,6 +40,18 @@
         }
     },
     "exceptions": {
+        "modbus_setup_failed": {
+            "message": "Não foi possível configurar a ligação Modbus: {error}"
+        },
+        "controller_read_failed": {
+            "message": "Não foi possível ler o modelo do controlador: {error}"
+        },
+        "unsupported_controller": {
+            "message": "Modelo de controlador não suportado: {model_id}"
+        },
+        "initial_read_failed": {
+            "message": "Não foi possível ler os dados iniciais do dispositivo: {error}"
+        },
         "write_unsupported": {
             "message": "The setting {field} cannot be written on the connected controller."
         },

--- a/custom_components/stiebel_eltron_isg/translations/sk.json
+++ b/custom_components/stiebel_eltron_isg/translations/sk.json
@@ -40,6 +40,18 @@
         }
     },
     "exceptions": {
+        "modbus_setup_failed": {
+            "message": "Nepodarilo sa nastaviť pripojenie Modbus: {error}"
+        },
+        "controller_read_failed": {
+            "message": "Nepodarilo sa prečítať model regulátora: {error}"
+        },
+        "unsupported_controller": {
+            "message": "Nepodporovaný model regulátora: {model_id}"
+        },
+        "initial_read_failed": {
+            "message": "Nepodarilo sa prečítať počiatočné údaje zariadenia: {error}"
+        },
         "write_unsupported": {
             "message": "The setting {field} cannot be written on the connected controller."
         },

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -318,6 +318,10 @@ async def test_async_setup_entry_rejects_unhandled_model(
     )
     assert issue is not None
     assert issue.translation_placeholders == {"model_id": "166"}
+    assert mock_config_entry.error_reason_translation_key == "unsupported_controller"
+    assert mock_config_entry.error_reason_translation_placeholders == {
+        "model_id": "166"
+    }
     assert mock_modbus_connection.connected is False
 
 

--- a/tests/test_setup_translations.py
+++ b/tests/test_setup_translations.py
@@ -1,0 +1,137 @@
+"""Setup errors keep their causes and provide HA translation metadata."""
+
+import json
+from pathlib import Path
+from string import Formatter
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.exceptions import (
+    ConfigEntryError,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+)
+from homeassistant.helpers.translation import async_get_translations
+from modbus_connection import ModbusError
+from pystiebeleltron import StiebelEltronModbusError, UnknownControllerModelError
+import pytest
+
+from custom_components import stiebel_eltron_isg as integration
+from custom_components.stiebel_eltron_isg.const import DOMAIN
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        (
+            "async_get_unit",
+            HomeAssistantError("link conflict"),
+            "modbus_setup_failed",
+            {"error": "link conflict"},
+            ConfigEntryState.SETUP_ERROR,
+        ),
+        (
+            "get_controller_model",
+            StiebelEltronModbusError(),
+            "controller_read_failed",
+            {"error": "Data error on the modbus"},
+            ConfigEntryState.SETUP_RETRY,
+        ),
+        (
+            "get_controller_model",
+            UnknownControllerModelError(165),
+            "unsupported_controller",
+            {"model_id": "165"},
+            ConfigEntryState.SETUP_ERROR,
+        ),
+        (
+            "update",
+            ModbusError("read timeout"),
+            "initial_read_failed",
+            {"error": "read timeout"},
+            ConfigEntryState.SETUP_RETRY,
+        ),
+    ],
+)
+async def test_setup_error_metadata_and_cause(
+    hass, mock_config_entry, mock_wpm_api, case
+):
+    target, failure, key, placeholders, state = case
+    mock_config_entry.add_to_hass(hass)
+    setup = integration.async_setup_entry
+    caught = []
+
+    async def capture(*args):
+        try:
+            return await setup(*args)
+        except (ConfigEntryError, ConfigEntryNotReady) as err:
+            caught.append(err)
+            raise
+
+    if target == "update":
+        mock_wpm_api.async_update.side_effect = failure
+        target = "get_controller_model"
+        replacement = integration.get_controller_model
+    else:
+        replacement = (
+            AsyncMock(side_effect=failure) if target == "get_controller_model" else None
+        )
+
+    with patch.object(integration, "async_setup_entry", side_effect=capture):
+        if replacement is not None:
+            with patch.object(integration, target, new=replacement):
+                assert not await hass.config_entries.async_setup(
+                    mock_config_entry.entry_id
+                )
+        else:
+            with patch.object(integration, target, side_effect=failure):
+                assert not await hass.config_entries.async_setup(
+                    mock_config_entry.entry_id
+                )
+
+    assert mock_config_entry.state is state
+    assert mock_config_entry.error_reason_translation_key == key
+    assert mock_config_entry.error_reason_translation_placeholders == placeholders
+    assert caught[0].translation_domain == DOMAIN
+    cause = caught[0].__cause__
+    while cause is not failure and cause is not None:
+        cause = cause.__cause__
+    assert cause is failure
+
+
+@pytest.mark.parametrize("language", ["en", "de"])
+async def test_setup_messages_resolve_through_home_assistant(hass, language):
+    translations = await async_get_translations(hass, language, "exceptions", {DOMAIN})
+    for key, values in {
+        "modbus_setup_failed": {"error": "link conflict"},
+        "controller_read_failed": {"error": "timeout"},
+        "unsupported_controller": {"model_id": "165"},
+        "initial_read_failed": {"error": "read timeout"},
+    }.items():
+        message = translations[f"component.{DOMAIN}.exceptions.{key}.message"]
+        rendered = message.format(**values)
+        assert all(value in rendered for value in values.values())
+        assert "{" not in rendered
+    assert ("Reglermodell" if language == "de" else "controller model") in translations[
+        f"component.{DOMAIN}.exceptions.unsupported_controller.message"
+    ]
+
+
+def test_all_setup_translation_resources_have_matching_placeholders():
+    root = Path(integration.__file__).parent
+    for path in [root / "strings.json", *(root / "translations").glob("*.json")]:
+        messages = json.loads(path.read_text())["exceptions"]
+        for key in (
+            "modbus_setup_failed",
+            "controller_read_failed",
+            "unsupported_controller",
+            "initial_read_failed",
+        ):
+            fields = {
+                field
+                for _, field, _, _ in Formatter().parse(messages[key]["message"])
+                if field
+            }
+            assert fields == (
+                {"model_id"} if key == "unsupported_controller" else {"error"}
+            ), path


### PR DESCRIPTION
Setup failures currently appear as untranslated text. Add translated messages for Modbus setup, controller detection, unsupported models and the initial data refresh, including all seven existing language files. Retry behavior and exception causes are preserved.

Tests cover Home Assistant translation lookup, placeholders, setup states and cause chains. All 961 tests pass with 99% coverage; Ruff, formatting, strict mypy and the per-module coverage gate pass.

The existing Czech file is named `cz.json`, while Home Assistant expects `cs`; correcting that pre-existing locale issue is outside this change.

## Summary by Sourcery

Provide translated and diagnostically complete setup errors for all supported integration setup failure paths.

New Features:
- Add localized setup error messages for Modbus setup, controller detection, unsupported models, and the initial data refresh across the existing translation resources.

Bug Fixes:
- Expose translated Home Assistant setup failure reasons while preserving retry behavior and underlying exception causes.

Tests:
- Add coverage for translation metadata, placeholders, resolved English and German messages, setup states, and exception cause chains.