### PR TITLE
Fix diagnostics export with current library APIs

### DIFF
--- a/custom_components/stiebel_eltron_isg/coordinator.py
+++ b/custom_components/stiebel_eltron_isg/coordinator.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from modbus_connection import ModbusError
 from modbus_connection.cli_helper import field_rows
+from modbus_connection.model import Component, ManualComponent
 from pystiebeleltron import ControllerModel, StiebelEltronModbusError
 
 from custom_components.stiebel_eltron_isg.const import (
@@ -139,6 +140,9 @@ class StiebelEltronDataCoordinator[T: StiebelEltronApi](
         """Return the raw data from the heat pump."""
         result: dict[str, Any] = {}
         for component in vars(self._api).values():
+            # APIs also contain polling helpers, which have no register fields.
+            if not isinstance(component, (Component, ManualComponent)):
+                continue
             component_result = dict(field_rows(component))
             result = {**result, **component_result}
         return result

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from modbus_connection import ModbusError
+from modbus_connection.model import Component, ManualComponent
 import pystiebeleltron
 from pystiebeleltron import ControllerModel, StiebelEltronModbusError
 import pytest
@@ -184,9 +185,11 @@ def test_model_name_is_readable(model, expected: str) -> None:
 
 def test_get_raw_data_combines_all_api_components() -> None:
     """Diagnostics receive the rows of every API component."""
-    first = object()
-    second = object()
-    coordinator = _coordinator(SimpleNamespace(first=first, second=second))
+    first = Component.__new__(Component)
+    second = ManualComponent.__new__(ManualComponent)
+    coordinator = _coordinator(
+        SimpleNamespace(first=first, second=second, _group=object())
+    )
 
     with patch.object(
         coordinator_module,
@@ -202,6 +205,7 @@ def test_get_raw_data_combines_all_api_components() -> None:
             "shared": 2,
         }
 
+    assert rows.call_count == 2
     assert rows.call_args_list[0].args == (first,)
     assert rows.call_args_list[1].args == (second,)
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8,10 +8,18 @@ from homeassistant.components.diagnostics import REDACTED
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import ExtendedJSONEncoder
+from modbus_connection.mock import MockModbusConnection
 from pystiebeleltron import ControllerModel
+from pystiebeleltron.lwz import LwzStiebelEltronAPI
+from pystiebeleltron.wpm import WpmStiebelEltronAPI
+from pystiebeleltron.wpm3i import Wpm3iStiebelEltronAPI
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.stiebel_eltron_isg.const import DOMAIN
+from custom_components.stiebel_eltron_isg.coordinator import (
+    StiebelEltronDataCoordinator,
+)
 from custom_components.stiebel_eltron_isg.diagnostics import (
     async_get_config_entry_diagnostics,
     async_get_device_diagnostics,
@@ -80,3 +88,38 @@ async def test_diagnostics_redact_host_and_preserve_useful_data(
             "model": "WPM_3",
             "model_id": 390,
         }
+
+
+@pytest.mark.parametrize(
+    ("api_class", "model", "address"),
+    [
+        (WpmStiebelEltronAPI, ControllerModel.WPMsystem, 506),
+        (Wpm3iStiebelEltronAPI, ControllerModel.WPM_3i, 506),
+        (LwzStiebelEltronAPI, ControllerModel.LWZ, 6),
+    ],
+)
+async def test_diagnostics_with_real_library_components(
+    hass, api_class, model, address
+):
+    """Export actual register values without treating API helpers as components."""
+    unit = MockModbusConnection().for_unit(1)
+    unit.load_raw({"input": {address: 125}})
+    api = api_class(unit)
+    await api.system_values.async_update()
+    coordinator = StiebelEltronDataCoordinator.__new__(StiebelEltronDataCoordinator)
+    coordinator._api = api
+    coordinator._model = model
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "private.example", CONF_PORT: 502}
+    )
+    entry.runtime_data = coordinator
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+    device_result = await async_get_device_diagnostics(hass, entry, SimpleNamespace())
+    assert result == device_result
+    assert result["data"][0]["outside_temperature"] == "12.5 °C"
+    assert "sg_ready_operating_state" in result["data"][0]
+    assert "operating_mode" in result["data"][0]
+    assert result["data"][1] == {"model": model.name, "model_id": model.value}
+    assert result["config_entry"][CONF_HOST] == REDACTED
+    assert "private.example" not in json.dumps(result, cls=ExtendedJSONEncoder)


### PR DESCRIPTION
Diagnostics fail with pystiebeleltron 0.7.0 because the API's internal polling helper is passed to the register formatter. Export only register components, preserving the existing diagnostic fields and host redaction.

Regression tests exercise both diagnostics endpoints with real WPM, WPM3i and LWZ API objects. All three cases reproduced the failure before the fix. On current main, including #685, all 964 tests pass with 99% coverage; every module exceeds 95%. Ruff, formatting and strict mypy pass.

Part of #629.

## Summary by Sourcery

Ensure diagnostics export only register components while preserving diagnostic data and privacy protections.

Bug Fixes:
- Fix diagnostics exports for current pystiebeleltron APIs by excluding internal polling helpers from register data collection.

Tests:
- Add regression coverage for diagnostics across WPM, WPM3i, and LWZ API implementations, including exported values, metadata, and host redaction.