### PR TITLE
Add a heat pump fault notification blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ twice.
 The separate **Total** sensors remain cumulative alternatives. Which energy
 entities are available depends on the connected controller.
 
+## Automation example
+
+Use the [heat pump fault notification blueprint](blueprints/automation/heat_pump_fault.yaml)
+to receive a notification when the ISG **Error Status** binary sensor changes
+to **On**. In Home Assistant, go to **Settings → Automations & scenes → Blueprints**,
+choose **Import blueprint**, and paste the GitHub URL of the linked YAML file.
+Create an automation from it and select your heat pump's Error Status entity.
+
+The default action creates a persistent notification in Home Assistant. You can
+replace it with your preferred notification action, such as a phone notification.
+It does not change heat pump settings or periodically repeat alerts. An existing
+fault is reported only when the entity next changes to On; unknown and unavailable
+states do not trigger an alert. This is a convenience notification, not a substitute
+for the heat pump's own fault display.
+
 ## Removing the integration
 
 1. Open **Settings → Devices & services**.

--- a/blueprints/automation/heat_pump_fault.yaml
+++ b/blueprints/automation/heat_pump_fault.yaml
@@ -15,6 +15,7 @@ blueprint:
           filter:
             - integration: stiebel_eltron_isg
               domain: binary_sensor
+              device_class: problem
     notification_action:
       name: Notification action
       description: Action to run when the heat pump reports a fault.

--- a/blueprints/automation/heat_pump_fault.yaml
+++ b/blueprints/automation/heat_pump_fault.yaml
@@ -1,0 +1,35 @@
+blueprint:
+  name: Stiebel Eltron ISG fault notification
+  description: >-
+    Notify when the selected ISG fault-status binary sensor changes to on.
+    The default action creates a persistent notification in Home Assistant.
+    Replace it with your preferred notification action if needed.
+    Unavailable and unknown states do not trigger notifications.
+  domain: automation
+  input:
+    fault_sensor:
+      name: Heat pump fault status
+      description: Select the Error Status entity of your Stiebel Eltron ISG.
+      selector:
+        entity:
+          filter:
+            - integration: stiebel_eltron_isg
+              domain: binary_sensor
+    notification_action:
+      name: Notification action
+      description: Action to run when the heat pump reports a fault.
+      default:
+        - action: persistent_notification.create
+          data:
+            title: Heat pump fault
+            message: >-
+              Your Stiebel Eltron ISG reports a fault. Check the heat pump
+              display or Servicewelt for details.
+      selector:
+        action: {}
+triggers:
+  - trigger: state
+    entity_id: !input fault_sensor
+    to: "on"
+actions: !input notification_action
+mode: single

--- a/custom_components/stiebel_eltron_isg/binary_sensor.py
+++ b/custom_components/stiebel_eltron_isg/binary_sensor.py
@@ -156,6 +156,7 @@ WPM_3I_BINARY_SENSOR_TYPES = [
     StiebelEltronBinarySensorEntityDescription(
         translation_key=ERROR_STATUS,
         key=ERROR_STATUS,
+        device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         modbus_register=lambda api: api.system_state.fault_status,
         bit_number=0,
@@ -465,6 +466,7 @@ LWZ_BINARY_SENSOR_TYPES = [
     StiebelEltronBinarySensorEntityDescription(
         translation_key=ERROR_STATUS,
         key=ERROR_STATUS,
+        device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         modbus_register=lambda api: api.system_state.fault_status,
     ),

--- a/custom_components/stiebel_eltron_isg/icons.json
+++ b/custom_components/stiebel_eltron_isg/icons.json
@@ -46,9 +46,6 @@
             "emergency_heating_2": {
                 "default": "mdi:fence-electric"
             },
-            "error_status": {
-                "default": "mdi:alert"
-            },
             "evaporator_defrost": {
                 "default": "mdi:snowflake-melt"
             },

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -1,12 +1,22 @@
 """Run the shipped blueprint through Home Assistant's actual automation engine."""
 
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 from homeassistant.components.automation.config import AUTOMATION_BLUEPRINT_SCHEMA
 from homeassistant.components.blueprint.models import Blueprint, BlueprintInputs
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.yaml import load_yaml
+from modbus_connection.mock import MockModbusConnection
+from pystiebeleltron import ControllerModel
+from pystiebeleltron.lwz import LwzStiebelEltronAPI
+from pystiebeleltron.wpm import WpmStiebelEltronAPI
+from pystiebeleltron.wpm3i import Wpm3iStiebelEltronAPI
 import pytest
+
+from custom_components.stiebel_eltron_isg.const import DOMAIN, ERROR_STATUS
+from custom_components.stiebel_eltron_isg.entity import build_unique_id
 
 BLUEPRINT_PATH = (
     Path(__file__).parent.parent / "blueprints/automation/heat_pump_fault.yaml"
@@ -56,3 +66,43 @@ async def test_fault_blueprint_only_notifies_for_active_fault(hass, custom_actio
     hass.states.async_set("binary_sensor.heat_pump_fault", "off")
     await hass.async_block_till_done()
     assert len(calls) == 1
+
+
+@pytest.mark.parametrize("model", list(ControllerModel))
+async def test_blueprint_selector_matches_only_fault_entity(
+    hass, mock_config_entry, mock_get_controller_model, model
+):
+    """Pump and compressor entities must not be offered as fault sensors."""
+    mock_get_controller_model.return_value = model
+    mock_config_entry.add_to_hass(hass)
+    if model in (ControllerModel.LWZ, ControllerModel.LWZ_x04_SOL):
+        module, api_class = "lwz_coordinator", LwzStiebelEltronAPI
+    elif model == ControllerModel.WPM_3i:
+        module, api_class = "wpm3i_coordinator", Wpm3iStiebelEltronAPI
+    else:
+        module, api_class = "wpm_coordinator", WpmStiebelEltronAPI
+    api = api_class(MockModbusConnection().for_unit(1))
+    api.async_update = AsyncMock()
+    with patch(
+        f"custom_components.stiebel_eltron_isg.{module}.{api_class.__name__}",
+        return_value=api,
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+    data = load_yaml(str(BLUEPRINT_PATH))
+    filters = data["blueprint"]["input"]["fault_sensor"]["selector"]["entity"]["filter"]
+    assert filters == [
+        {"integration": DOMAIN, "domain": "binary_sensor", "device_class": "problem"}
+    ]
+    entries = er.async_entries_for_config_entry(
+        er.async_get(hass), mock_config_entry.entry_id
+    )
+    selectable = [
+        entry
+        for entry in entries
+        if entry.domain == "binary_sensor"
+        and hass.states.get(entry.entity_id).attributes.get("device_class") == "problem"
+    ]
+    assert [entry.unique_id for entry in selectable] == [
+        build_unique_id(mock_config_entry, ERROR_STATUS)
+    ]

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -1,0 +1,58 @@
+"""Run the shipped blueprint through Home Assistant's actual automation engine."""
+
+from pathlib import Path
+
+from homeassistant.components.automation.config import AUTOMATION_BLUEPRINT_SCHEMA
+from homeassistant.components.blueprint.models import Blueprint, BlueprintInputs
+from homeassistant.setup import async_setup_component
+from homeassistant.util.yaml import load_yaml
+import pytest
+
+BLUEPRINT_PATH = (
+    Path(__file__).parent.parent / "blueprints/automation/heat_pump_fault.yaml"
+)
+
+
+@pytest.mark.parametrize("custom_action", [False, True])
+async def test_fault_blueprint_only_notifies_for_active_fault(hass, custom_action):
+    blueprint = Blueprint(
+        load_yaml(str(BLUEPRINT_PATH)),
+        expected_domain="automation",
+        schema=AUTOMATION_BLUEPRINT_SCHEMA,
+    )
+    inputs = {"fault_sensor": "binary_sensor.heat_pump_fault"}
+    calls = []
+
+    async def capture(call):
+        calls.append(call.data)
+
+    hass.services.async_register("test", "notify", capture)
+    if custom_action:
+        inputs["notification_action"] = [
+            {"action": "test.notify", "data": {"message": "fault"}}
+        ]
+    else:
+        hass.services.async_register("persistent_notification", "create", capture)
+    configured = BlueprintInputs(blueprint, {"use_blueprint": {"input": inputs}})
+    configured.validate()
+    config = configured.async_substitute()
+    config["id"] = "test_fault_blueprint"
+    hass.states.async_set("binary_sensor.heat_pump_fault", "off")
+    assert await async_setup_component(hass, "automation", {"automation": config})
+    await hass.async_block_till_done()
+    for state in ("unknown", "unavailable", "off"):
+        hass.states.async_set("binary_sensor.heat_pump_fault", state)
+        await hass.async_block_till_done()
+    assert calls == []
+    hass.states.async_set("binary_sensor.heat_pump_fault", "on")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert "fault" in calls[0]["message"].lower()
+    hass.states.async_set(
+        "binary_sensor.heat_pump_fault", "on", {"friendly_name": "Updated name"}
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    hass.states.async_set("binary_sensor.heat_pump_fault", "off")
+    await hass.async_block_till_done()
+    assert len(calls) == 1


### PR DESCRIPTION
Add an importable automation blueprint that notifies when the ISG Error Status binary sensor changes to on. The default action creates a persistent Home Assistant notification; users can select another notification action. It does not write heat pump settings. The existing fault-status entities now use the problem device class, so the selector excludes pump and compressor states; their icons follow Home Assistant's device-class defaults.

The README explains import, setup and limitations. Tests load the blueprint through Home Assistant and run both default and custom actions, checking that unknown/unavailable states and attribute-only changes do not notify. The selector is tested against real API objects for all six controller models. All 969 tests pass; Ruff, formatting and strict mypy pass.

Part of #629 (`docs-examples`).

## Summary by Sourcery

Provide a configurable automation blueprint for notifying users when an ISG heat pump fault becomes active.

New Features:
- Add an importable Home Assistant automation blueprint that notifies users when a Stiebel Eltron ISG heat pump reports a fault.

Enhancements:
- Classify heat pump fault-status binary sensors as problem entities and use Home Assistant’s default device-class icons.
- Document blueprint setup, notification behavior, and limitations in the README.

Documentation:
- Add user-facing documentation for importing and configuring the heat pump fault notification blueprint.

Tests:
- Test blueprint notifications for active faults, custom actions, ignored transient states, and attribute-only changes across all controller models.